### PR TITLE
Cleanup of documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Service name  | Units                                     | Description
 ------------- |-------------------------------------------|------------
 `meter_elec`  | kWh, kVAh, W, pulse_c, V, A, power_factor | Electric meter
 `meter_gas`   | cub_m, cub_f, pulse_c                     | Gas meter
-`meter_water` | cub_m, cub_f, galon, pulse_c              | Water meter
+`meter_water` | cub_m, cub_f, gallon, pulse_c              | Water meter
 
 #### Interfaces
 

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ Service name        | Event                                   | Description
 `alarm_system`      | hw_failure, sw_failure, hw_failure_with_code, sw_failure_with_code |
 `alarm_emergency`   | police, fire, medical                   |
 `alarm_time`        | wakeup, timer_ended, time_remaining     |
-`alarm_applience`   | program_started, program_inprogress, program_completed, replace_filter, set_temp_error, supplying_water, water_supply_err, boiling, boiling_err, washing, washing_err, rinsing, rinsing_err, draining, draining_err, spinnning, spinning_err, drying, drying_err, fan_err, compressor_err |
+`alarm_appliance`   | program_started, program_inprogress, program_completed, replace_filter, set_temp_error, supplying_water, water_supply_err, boiling, boiling_err, washing, washing_err, rinsing, rinsing_err, draining, draining_err, spinnning, spinning_err, drying, drying_err, fan_err, compressor_err |
 `alarm_health`      | leaving_bed, sitting_on_bed, lying_on_bed, alarm_health, posture_change, sitting_on_bed_edge, alarm_health, volatile_organic_compound |
 `alarm_siren`       | inactive, siren_active                  |
 `alarm_water_valve` | valve_op, master_valve_op, alarm_water_valve, valve_short_circuit, current_alarm, alarm_water_valve, master_valve_current_alarm |

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ in   | cmd.config.get_supp_list    | null       | Requests service to respond wi
 in   | cmd.config.set              | str_map    | Sets configuration. Value is a key-value pairs.
 in   | cmd.config.supp_list_report | str_map    | List of supported configurations. Key - config name, value - short description.
 out  | evt.config.report           | str_map    | Reports configurations in form of key-value pairs.
-|||
+-|-|-|-
 in   | cmd.group.add_members       | object     | Adds members to the group. Object has the same format as members_report
 in   | cmd.group.delete_members    | object     | Object has the same format as report.
 in   | cmd.group.get_members       | string     | Value is a group name.
@@ -120,7 +120,7 @@ Type | Interface          | Value type | Properties              | Description
 -----|--------------------|------------|-------------------------|------------
 in   | cmd.binary.set     | bool       |                         | true is mapped to 255, false to 0
 out  | evt.binary.report  | bool       |                         |
-|||
+-|-|-|-
 in   | cmd.lvl.get_report | null       |                         |
 in   | cmd.lvl.set        | int        | `duration`              |
 in   | cmd.lvl.start      | string     | `start_lvl`, `duration` |
@@ -313,7 +313,7 @@ Type | Interface          | Value type | Properties | Description
 -----|--------------------|------------|----------- |------------------
 in   | cmd.lvl.get_report | null       |            | Get battery level over level report.
 out  | evt.lvl.report     | int        | state      |
-|||
+-|-|-|-
 out  | evt.alarm.report   | str_map    |            | val = {"event": "low_battery", "status": "activ"}
 
 #### Interface props
@@ -335,11 +335,11 @@ Type | Interface               | Value type | Description
 in   | cmd.mode.get_report     | null       |
 in   | cmd.mode.set            | string     |  Set thermostat mode:
 out  | evt.mode.report         | string     |
-|||
+-|-|-|-
 in   | cmd.setpoint.get_report | string     | value is a set-point type
 in   | cmd.setpoint.set        | str_map    | val = {"type":"heat", "temp":"21.5", "unit":"C"}
 out  | evt.setpoint.report     | str_map    | val = {"type":"heat", "temp":"21.5", "unit":"C"}
-|||
+-|-|-|-
 in   | cmd.state.get_report    | null       |
 out  | evt.state.report        | string     |  Reports operational state.
 
@@ -478,15 +478,15 @@ Type | Interface              | Value type |  Description
 in   | cmd.lvl.get_report     | null       | The command is a request for current fan speed level.
 in   | cmd.lvl.set            | int        | Fan speed, value 0 - 100 %
 out  | evt.lvl.report         | null       | Current fan speed level.
-|||
+-|-|-|-
 in   | cmd.mode.get_report    | null       | The command is a request for current fan mode report.
 in   | cmd.mode.set           | string     | Fan mode. Supported values: auto_low, auto_high, auto_mid, low, high, mid,  humid_circulation, up_down,  left_right, quiet
 out  | evt.mode.report        | string     | Current fan mode
-|||
+-|-|-|-
 in   | cmd.modelvl.get_report | string     | The command is a request for fan speed level for particular mode. If mode is set to "", the device should report levels for all modes.
 in   | cmd.modelvl.set        | int_map    | val = {"mid":90, "auto_low":10}
 out  | evt.modelvl.report     | int_map    | val = {"mid":90, "auto_low":10}
-|||
+-|-|-|-
 in   | cmd.state.get_report   | null       | The command is a request for current fan state report
 out  | evt.state.report       | string     | Report operational state. Supported values: idle, low, high, mid
 
@@ -534,12 +534,12 @@ Type | Interface                | Value type | Description
 in   | cmd.notiftype.get_report | null       |
 in   | cmd.notiftype.set        | bool_map   | Configuration of notification type device is is using while opening/closing door.
 out  | evt.notiftype.report     | bool_map   |
-|||
+-|-|-|-
 in   | cmd.op.stop              | null       | Emergency stop of any operation.
-|||
+-|-|-|-
 in   | cmd.state.get_report     | null       | Get current state
 out  | evt.state.report         | string     | Current state
-|||
+-|-|-|-
 in   | cmd.tstate.set           | string     | Setting target state
 
 Topic example: `pt:j1/mt:evt/rt:dev/rn:zw/ad:1/sv:berier_ctrl/ad:15_0`

--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ A generic service and the most simple way to interact with a device. The actual 
 
 Type | Interface          | Value type | Description
 -----|--------------------|------------|------------
-out  | evt.lvl.report     | int        | Reports level using numeric value
-in   | cmd.lvl.set        | int        | Sets level using numeric value
 in   | cmd.lvl.get_report | null       |
+in   | cmd.lvl.set        | int        | Sets level using numeric value
+out  | evt.lvl.report     | int        | Reports level using numeric value
 
 Topic example: `pt:j1/mt:evt/rt:dev/rn:zw/ad:1/sv:basic/ad:15_0`
 
@@ -67,15 +67,16 @@ Topic example: `pt:j1/mt:evt/rt:dev/rn:zw/ad:1/sv:basic/ad:15_0`
 
 Type | Interface                   | Value type | Description
 -----|---------------------------- |------------|------------
-out  | evt.config.report           | str_map    | Reports configurations in form of key-value pairs.
-in   | cmd.config.set              | str_map    | Sets configuration. Value is a key-value pairs.
 in   | cmd.config.get_report       | str_array  | Requests service to respond with config report. If array is empty - report all parameters.
 in   | cmd.config.get_supp_list    | null       | Requests service to respond with a list of supported configurations.
+in   | cmd.config.set              | str_map    | Sets configuration. Value is a key-value pairs.
 in   | cmd.config.supp_list_report | str_map    | List of supported configurations. Key - config name, value - short description.
-out  | evt.group.members_report    | object     | Object structure {"group":"group1", "members":["node1", "node2"]}
+out  | evt.config.report           | str_map    | Reports configurations in form of key-value pairs.
+-----|---------------------------- |------------|------------
 in   | cmd.group.add_members       | object     | Adds members to the group. Object has the same format as members_report
 in   | cmd.group.delete_members    | object     | Object has the same format as report.
 in   | cmd.group.get_members       | string     | Value is a group name.
+out  | evt.group.members_report    | object     | Object structure {"group":"group1", "members":["node1", "node2"]}
 
 #### Notes
 
@@ -97,9 +98,9 @@ Output binary switch service for wall-plugs, relays, simple sirens, etc.
 
 Type | Interface             | Value type | Description
 -----|-----------------------|------------|------------
-out  | evt.binary.report     | bool       | Reports true when switch is ON and false when switch is OFF
-in   | cmd.binary.set        | bool       |
 in   | cmd.binary.get_report | null       |
+in   | cmd.binary.set        | bool       |
+out  | evt.binary.report     | bool       | Reports true when switch is ON and false when switch is OFF
 
 Topic example: `pt:j1/mt:cmd/rt:dev/rn:zw/ad:1/sv:out_bin_switch/ad:15_0`
 
@@ -117,13 +118,14 @@ Used for dimmers and things generally controlled with sliders.
 
 Type | Interface          | Value type | Properties              | Description
 -----|--------------------|------------|-------------------------|------------
-out  | evt.lvl.report     | int        |                         |
+in   | cmd.binary.set     | bool       |                         | true is mapped to 255, false to 0
+out  | evt.binary.report  | bool       |                         |
+-----|--------------------|------------|-------------------------|------------
+in   | cmd.lvl.get_report | null       |                         |
 in   | cmd.lvl.set        | int        | `duration`              |
 in   | cmd.lvl.start      | string     | `start_lvl`, `duration` |
 in   | cmd.lvl.stop       | null       |                         | Stop a level change
-in   | cmd.lvl.get_report | null       |                         |
-in   | cmd.binary.set     | bool       |                         | true is mapped to 255, false to 0
-out  | evt.binary.report  | bool       |                         |
+out  | evt.lvl.report     | int        |                         |
 
 Topic example: `pt:j1/mt:cmd/rt:dev/rn:zw/ad:1/sv:out_lvl_switch/ad:15_0`
 
@@ -138,8 +140,8 @@ Name        | Value example | Description
 
 Name      | Value example | Description
 ----------|---------------|-------------
-`min_lvl` | 0             | minimum value.
 `max_lvl` | 99            | maximum value.
+`min_lvl` | 0             | minimum value.
 `sw_type` | "on_off"      | type of level switch. Supported values are "on_off" or "up_down".
 
 ***
@@ -160,19 +162,19 @@ Service name  | Units                                     | Description
 
 Type | Interface            | Value type | Properties              | Description
 -----|----------------------|------------|-------------------------|-------------
-out  | evt.meter.report     | float      | unit, prv_data, delta_t |
-in   | cmd.meter.reset      | null       |                         | Resets all historical readings.
 in   | cmd.meter.get_report | string     |                         | Value - is a unit. May not be supported by all meters.
+in   | cmd.meter.reset      | null       |                         | Resets all historical readings.
+out  | evt.meter.report     | float      | unit, prv_data, delta_t |
 
 Topic example: `pt:j1/mt:evt/rt:dev/rn:zw/ad:1/sv:meter_elec/ad:15_0`
 
 #### Interface props
 
-Name     | Value example | Description
----------|---------------|-------------
-unit     |               |
-prv_data |               | previous meter reading
-delta_t  |               | time delta
+Name       | Value example | Description
+-----------|---------------|-------------
+`delta_t`  |               | time delta
+`prv_data` |               | previous meter reading
+`unit`     |               |
 
 #### Service props
 
@@ -227,16 +229,16 @@ Service name         | Units                    | Description
 
 Type | Interface             | Value type | Properties | Description
 -----|-----------------------|------------|------------|-------------
-out  | evt.sensor.report     | float      | unit       |
 in   | cmd.sensor.get_report | string     |            | Value is desired unit. Use empty value to get report in default unit.
+out  | evt.sensor.report     | float      | unit       |
 
 Example message: [evt.sensor.report](json-v1/messages/examples/evt.sensor.report)
 
 #### Service props
 
-Name      | Value example | Description
-----------|---------------|-------------
-sup_units | ["C", "F"]    | list of supported units.
+Name        | Value example | Description
+------------|---------------|-------------
+`sup_units` | ["C", "F"]    | list of supported units.
 
 ***
 
@@ -253,8 +255,8 @@ Service name         | Units | Description
 
 Type | Interface           | Value type | Description
 -----|---------------------|------------|--------------------
-out  | evt.open.report     | bool       |
 in   | cmd.open.get_report | null       |
+out  | evt.open.report     | bool       |
 
 ***
 
@@ -264,28 +266,28 @@ in   | cmd.open.get_report | null       |
 
 Service name        | Event                                   | Description
 --------------------|-----------------------------------------|------------
-`alarm_fire`        | smoke, smoke_test                       |
-`alarm_heat`        | overheat, temp_rise, underheat          |
-`alarm_gas`         | CO, CO2, combust_gas_detected, toxic_gas_detected, test, replace |
-`alarm_water`       | leak, level_drop, replace_filter        |
-`alarm_lock`        | manual_lock, rf_lock, keypad_lock, manual_not_locked, rf_not_locked, auto_locked, jammed | TODO: move to doorlock service
-`alarm_burglar`     | intrusion, tamper_removed_cover, alarm_burglar, tamper_invalid_code, glass_breakage |
-`alarm_power`       | on, ac_on, ac_off, surge, voltage_drop, over_current, over_voltage, replace_soon, replace_now, charging, charged, charge_soon, charge_now | TODO: move to power_supply service
-`alarm_system`      | hw_failure, sw_failure, hw_failure_with_code, sw_failure_with_code |
-`alarm_emergency`   | police, fire, medical                   |
-`alarm_time`        | wakeup, timer_ended, time_remaining     |
 `alarm_appliance`   | program_started, program_inprogress, program_completed, replace_filter, set_temp_error, supplying_water, water_supply_err, boiling, boiling_err, washing, washing_err, rinsing, rinsing_err, draining, draining_err, spinning, spinning_err, drying, drying_err, fan_err, compressor_err |
+`alarm_burglar`     | intrusion, tamper_removed_cover, alarm_burglar, tamper_invalid_code, glass_breakage |
+`alarm_emergency`   | police, fire, medical                   |
+`alarm_fire`        | smoke, smoke_test                       |
+`alarm_gas`         | CO, CO2, combust_gas_detected, toxic_gas_detected, test, replace |
 `alarm_health`      | leaving_bed, sitting_on_bed, lying_on_bed, alarm_health, posture_change, sitting_on_bed_edge, alarm_health, volatile_organic_compound |
+`alarm_heat`        | overheat, temp_rise, underheat          |
+`alarm_lock`        | manual_lock, rf_lock, keypad_lock, manual_not_locked, rf_not_locked, auto_locked, jammed | TODO: move to doorlock service
+`alarm_power`       | on, ac_on, ac_off, surge, voltage_drop, over_current, over_voltage, replace_soon, replace_now, charging, charged, charge_soon, charge_now | TODO: move to power_supply service
 `alarm_siren`       | inactive, siren_active                  |
+`alarm_system`      | hw_failure, sw_failure, hw_failure_with_code, sw_failure_with_code |
+`alarm_time`        | wakeup, timer_ended, time_remaining     |
 `alarm_water_valve` | valve_op, master_valve_op, alarm_water_valve, valve_short_circuit, current_alarm, alarm_water_valve, master_valve_current_alarm |
+`alarm_water`       | leak, level_drop, replace_filter        |
 `alarm_weather`     | inactive, moisture                      |
 
 #### Interfaces
 
 Type | Interface            | Value type | Description
 -----|----------------------|------------|--------------------
-out  | evt.alarm.report     | str_map    | val = {"event": "tamper_removed_cover", "status": "activ"}
 in   | cmd.alarm.get_report | ?          |
+out  | evt.alarm.report     | str_map    | val = {"event": "tamper_removed_cover", "status": "activ"}
 
 Supported statuses: activ, deactiv. IMPORTANT: These are shorthands for "activated" and "deactivated", not typos.
 
@@ -293,9 +295,9 @@ Example message: [evt.sensor.report](json-v1/messages/examples/evt.alarm.report.
 
 #### Service props
 
-Name       | Value example           | Description
------------|-------------------------|-------------
-sup_events | ["smoke", "smoke_test"] | supported events.
+Name         | Value example           | Description
+-------------|-------------------------|-------------
+`sup_events` | ["smoke", "smoke_test"] | supported events.
 
 ***
 
@@ -309,15 +311,16 @@ sup_events | ["smoke", "smoke_test"] | supported events.
 
 Type | Interface          | Value type | Properties | Description
 -----|--------------------|------------|----------- |------------------
-out  | evt.lvl.report     | int        | state      |
-out  | evt.alarm.report   | str_map    |            | val = {"event": "low_battery", "status": "activ"}
 in   | cmd.lvl.get_report | null       |            | Get battery level over level report.
+out  | evt.lvl.report     | int        | state      |
+-----|--------------------|------------|----------- |------------------
+out  | evt.alarm.report   | str_map    |            | val = {"event": "low_battery", "status": "activ"}
 
 #### Interface props
 
-Name  | Value example | Description
-------|---------------|-------------
-state | "charging"    | available states: charging, charged, replace, emtpy
+Name    | Value example | Description
+--------|---------------|-------------
+`state` | "charging"    | available states: charging, charged, replace, emtpy
 
 ### Thermostat service
 
@@ -329,22 +332,24 @@ state | "charging"    | available states: charging, charged, replace, emtpy
 
 Type | Interface               | Value type | Description
 -----|-------------------------|------------|------------------
-out  | evt.setpoint.report     | str_map    | val = {"type":"heat", "temp":"21.5", "unit":"C"}
-in   | cmd.setpoint.set        | str_map    | val = {"type":"heat", "temp":"21.5", "unit":"C"}
-in   | cmd.setpoint.get_report | string     | value is a set-point type
-in   | cmd.mode.set            | string     |  Set thermostat mode:
 in   | cmd.mode.get_report     | null       |
+in   | cmd.mode.set            | string     |  Set thermostat mode:
 out  | evt.mode.report         | string     |
-out  | evt.state.report        | string     |  Reports operational state.
+-----|-------------------------|------------|------------------
+in   | cmd.setpoint.get_report | string     | value is a set-point type
+in   | cmd.setpoint.set        | str_map    | val = {"type":"heat", "temp":"21.5", "unit":"C"}
+out  | evt.setpoint.report     | str_map    | val = {"type":"heat", "temp":"21.5", "unit":"C"}
+-----|-------------------------|------------|------------------
 in   | cmd.state.get_report    | null       |
+out  | evt.state.report        | string     |  Reports operational state.
 
 #### Service props
 
-Name           | Value example                                                                  | Description
----------------|--------------------------------------------------------------------------------|-------------
-sup_setpoints  | heat, cool                                                                     | supported set-points.
-sup_modes      | off, heat, cool                                                                | supported modes.
-sup_states     | idle, heat, cool, idle, heat, cool, fan_only, pending_heat, pending_cool, vent |
+Name            | Value example                                                                  | Description
+----------------|--------------------------------------------------------------------------------|-------------
+`sup_modes`     | off, heat, cool                                                                | supported modes.
+`sup_setpoints` | heat, cool                                                                     | supported set-points.
+`sup_states`    | idle, heat, cool, idle, heat, cool, fan_only, pending_heat, pending_cool, vent |
 
 Modes: off, heat, cool, auto, aux_heat, resume, fan, furnace, dry_air, moist_air, auto_changeover, energy_heat, energy_cool, away.
 
@@ -360,23 +365,23 @@ Set-point types: heat, cool, furnace, dry_air, moist_air, auto_changeover, energ
 
 Type | Interface               | Value type | Properties           | Description
 -----|-------------------------|------------|----------------------|------------------
-out  | evt.lock.report         | bool_map   | timeout_s, lock_type | value = {"is_secured":true, "door_is_closed":true, "bolt_is_locked":true, "latch_is_closed":true}
+in   | cmd.lock.get_report     | null       |                      |
 in   | cmd.lock.set            | bool       |                      | Use true to secure a lock and false to unsecure
 in   | cmd.lock.set_with_code  | str_map    |                      | Used to lock/unlock locks required PIN/RFID, {“op”:”lock”, ”code_type”:”pin”, ”12345” }
-in   | cmd.lock.get_report     | null       |                      |
+out  | evt.lock.report         | bool_map   | timeout_s, lock_type | value = {"is_secured":true, "door_is_closed":true, "bolt_is_locked":true, "latch_is_closed":true}
 
 #### Interface props
 
-Name      | Value example | Description
-----------|---------------|-------------
-timeout_s |               |
-lock_type | "key"         | how lock was activated, it can take values: "key", "pin", "rfid"
+Name        | Value example | Description
+------------|---------------|-------------
+`lock_type` | "key"         | how lock was activated, it can take values: "key", "pin", "rfid"
+`timeout_s` |               |
 
 #### Service props
 
-Name           | Value example                                                         | Description
----------------|-----------------------------------------------------------------------|-------------
-sup_components | ["is_secured", "door_is_closed", "bolt_is_locked", "latch_is_closed"] | List of supported lock component components
+Name             | Value example                                                         | Description
+-----------------|-----------------------------------------------------------------------|-------------
+`sup_components` | ["is_secured", "door_is_closed", "bolt_is_locked", "latch_is_closed"] | List of supported lock component components
 
 ### User code service
 
@@ -388,19 +393,19 @@ Is used by door locks, keypads, security panels to enter and manage pin codes an
 
 Type | Interface                      | Value type | Description
 -----|--------------------------------|------------|------------------
-out  | evt.usercode.config_report     | str_map    | {"user_id":"123", "user_status":"enabled", "user_type":"master", "code_type":"rfid", "code":"4321"}
-in   | cmd.usercode.set               | str_map    | {"user_id":"123", "user_status":"enabled", "user_type":"master", "code_type":"rfid", "code":"4321"}
-in   | cmd.usercode.get_config_report | str_map    | {"user_id":"123", "code_type":"rfid"}, code type should be either "all" or one of supported types
-in   | cmd.usercode.clear_all         | null       | Clear all codes
 in   | cmd.usercode.clear             | str_map    | {"user_id":"123", "code_type":"rfid"}, code type should be either "all" or one of supported types
+in   | cmd.usercode.clear_all         | null       | Clear all codes
+in   | cmd.usercode.get_config_report | str_map    | {"user_id":"123", "code_type":"rfid"}, code type should be either "all" or one of supported types
+in   | cmd.usercode.set               | str_map    | {"user_id":"123", "user_status":"enabled", "user_type":"master", "code_type":"rfid", "code":"4321"}
+out  | evt.usercode.config_report     | str_map    | {"user_id":"123", "user_status":"enabled", "user_type":"master", "code_type":"rfid", "code":"4321"}
 
 #### Service props
 
-Name           | Value example              | Description
----------------|----------------------------|-------------
-sup_usercodes  | ["pin", "rfid"]            | List of supported user code types
-sup_usertypes  | ["master", "unrestricted"] | List of supported user code types
-sup_userstatus | ["enabled", "disabled"]    | List of supported user code types
+Name             | Value example              | Description
+-----------------|----------------------------|-------------
+`sup_usercodes`  | ["pin", "rfid"]            | List of supported user code types
+`sup_userstatus` | ["enabled", "disabled"]    | List of supported user code types
+`sup_usertypes`  | ["master", "unrestricted"] | List of supported user code types
 
 ### Color control service
 
@@ -414,23 +419,26 @@ The service has to be used to control color components of a lightning device.
 
 Type | Interface            | Value type |  Description
 -----|----------------------|------------|-------------------
-in   | cmd.color.set        | int_map    | value is a map of color components. val= {"red":200, "green":100, "blue":45}
 in   | cmd.color.get_report | null       | The command is a request for a map of color component values
+in   | cmd.color.set        | int_map    | value is a map of color components. val= {"red":200, "green":100, "blue":45}
 out  | evt.color.report     | int_map    | Map of color components, where value is component intensity.
 
 #### Service props
 
-Name           | Value example            | Description
----------------|--------------------------|-------------
-sup_components | ["red", "green", "blue"] | List of supported color components
+Name             | Value example            | Description
+-----------------|--------------------------|-------------
+`sup_components` | ["red", "green", "blue"] | List of supported color components
 
 Supported color components: red, green, blue, warm_w, cold_w, temp, amber, cyan, purple
 
 #### Notes
 
 - temp - is color temperature in Kalvin. Value range 1000K-10000K.
+
 - warm_w - is warm white light source intensity.Value range 0-255.
+
 - cold_w - is cold white light source intensity.Value range 0-255.
+
 - Mix of warm white intensity and cold white intensity forms color temperature.
 
 ### Scene controller service
@@ -451,9 +459,9 @@ out  | evt.scene.report     | string     | Event is generated whenever scene but
 
 #### Service props
 
-Name       | Value example | Description
------------|---------------|-------------
-sup_scenes | 1, a, movies  | List of supported scenes
+Name         | Value example | Description
+-------------|---------------|-------------
+`sup_scenes` | 1, a, movies  | List of supported scenes
 
 ### Fan control service
 
@@ -467,24 +475,27 @@ The service has to be used to control a fan operational modes, speed and receive
 
 Type | Interface              | Value type |  Description
 -----|------------------------|------------|-------------------
-in   | cmd.mode.set           | string     | Fan mode. Supported values: auto_low, auto_high, auto_mid, low, high, mid,  humid_circulation, up_down,  left_right, quiet
-in   | cmd.mode.get_report    | null       | The command is a request for current fan mode report.
-out  | evt.mode.report        | string     | Current fan mode
-out  | evt.state.report       | string     | Report operational state. Supported values: idle, low, high, mid
-in   | cmd.state.get_report   | null       | The command is a request for current fan state report
-in   | cmd.lvl.set            | int        | Fan speed, value 0 - 100 %
 in   | cmd.lvl.get_report     | null       | The command is a request for current fan speed level.
+in   | cmd.lvl.set            | int        | Fan speed, value 0 - 100 %
 out  | evt.lvl.report         | null       | Current fan speed level.
-in   | cmd.modelvl.set        | int_map    | val = {"mid":90, "auto_low":10}
+-----|------------------------|------------|-------------------
+in   | cmd.mode.get_report    | null       | The command is a request for current fan mode report.
+in   | cmd.mode.set           | string     | Fan mode. Supported values: auto_low, auto_high, auto_mid, low, high, mid,  humid_circulation, up_down,  left_right, quiet
+out  | evt.mode.report        | string     | Current fan mode
+-----|------------------------|------------|-------------------
 in   | cmd.modelvl.get_report | string     | The command is a request for fan speed level for particular mode. If mode is set to "", the device should report levels for all modes.
+in   | cmd.modelvl.set        | int_map    | val = {"mid":90, "auto_low":10}
 out  | evt.modelvl.report     | int_map    | val = {"mid":90, "auto_low":10}
+-----|------------------------|------------|-------------------
+in   | cmd.state.get_report   | null       | The command is a request for current fan state report
+out  | evt.state.report       | string     | Report operational state. Supported values: idle, low, high, mid
 
 #### Service props
 
-Name       | Value example      | Description
------------|--------------------|-------------
-sup_modes  | auto_low, auto_mid | List of supported modes
-sup_states | idle, low, high    |
+Name         | Value example      | Description
+-------------|--------------------|-------------
+`sup_modes`  | auto_low, auto_mid | List of supported modes
+`sup_states` | idle, low, high    |
 
 ### Siren service
 
@@ -496,17 +507,17 @@ sup_states | idle, low, high    |
 
 Type | Interface           | Value type | Description
 -----|---------------------|------------|------------
+in   | cmd.mode.get_report | null       |
 in   | cmd.mode.set        | string     | Control siren using selected tone
 out  | evt.mode.report     | string     |
-in   | cmd.mode.get_report | null       |
 
 Topic example: `pt:j1/mt:evt/rt:dev/rn:zw/ad:1/sv:siren_ctrl/ad:15_0`
 
 #### Service props
 
-Name           | Value example       | Description
----------------|---------------------|-------------
-sup_modes      | on, off, fire, leak | List of supported tones
+Name             | Value example       | Description
+-----------------|---------------------|-------------
+`sup_modes`      | on, off, fire, leak | List of supported tones
 
 ### Barrier control service
 
@@ -520,23 +531,26 @@ The service represent devices like garage door openers, barriers, window protect
 
 Type | Interface                | Value type | Description
 -----|--------------------------|------------|------------
-in   | cmd.tstate.set           | string     | Setting target state
-in   | cmd.op.stop              | null       | Emergency stop of any operation.
-out  | evt.state.report         | string     | Current state
-in   | cmd.state.get_report     | null       | Get current state
-in   | cmd.notiftype.set        | bool_map   | Configuration of notification type device is is using while opening/closing door.
 in   | cmd.notiftype.get_report | null       |
+in   | cmd.notiftype.set        | bool_map   | Configuration of notification type device is is using while opening/closing door.
 out  | evt.notiftype.report     | bool_map   |
+-----|--------------------------|------------|------------
+in   | cmd.op.stop              | null       | Emergency stop of any operation.
+-----|--------------------------|------------|------------
+in   | cmd.state.get_report     | null       | Get current state
+out  | evt.state.report         | string     | Current state
+-----|--------------------------|------------|------------
+in   | cmd.tstate.set           | string     | Setting target state
 
 Topic example: `pt:j1/mt:evt/rt:dev/rn:zw/ad:1/sv:berier_ctrl/ad:15_0`
 
 #### Service props
 
-Name           | Value example         | Description
----------------|-----------------------|-------------
-sup_states     | open, closed, closing | supported states
-sup_tstates    | open, close           | supported target states
-sup_notiftypes | audio, visual         | supported notifications types, like siren, flashlight
+Name             | Value example         | Description
+-----------------|-----------------------|-------------
+`sup_notiftypes` | audio, visual         | supported notifications types, like siren, flashlight
+`sup_states`     | open, closed, closing | supported states
+`sup_tstates`    | open, close           | supported target states
 
 ### Complex alarm system service
 
@@ -564,7 +578,7 @@ The service represents gateway, hub or host computer. Adapter topic should be us
 
 Type | Interface                 | Value type | Description
 -----|---------------------------|------------|------------
+in   | cmd.gateway.factory_reset | null       | Instructs gateway to perform factory reset
 in   | cmd.gateway.reboot        | null       | Gateways reboot
 in   | cmd.gateway.shutdown      | null       | Gateways shutdown
-in   | cmd.gateway.factory_reset | null       | Instructs gateway to perform factory reset
 out  | evt.gateway.factory_reset | null       | Factory reset event.

--- a/README.md
+++ b/README.md
@@ -53,8 +53,6 @@ Breaking down the example `pt:j1/mt:evt/rt:dev/rn:zw/ad:1/sv:out_bin_switch/ad:1
 
 Lastly, not that each interface within a service share the same address and that a service can never have more than one interface of the same type.
 
-Message format:
-
 [FIMP message format](message-format.md)
 
 ## Component discovery mechanism

--- a/README.md
+++ b/README.md
@@ -225,37 +225,21 @@ sup_units | ["C", "F"]    | list of supported units.
 
 ***
 
-### Contact sensor service
-
-Binary contact sensor, normally magnetic contact.
+### Binary sensor services
 
 #### Service names
 
-`sensor_contact`
+Service name         | Units                | Description
+---------------------|----------------------|------------
+`sensor_contact`     |                      | Binary contact sensor, normally magnetic contact. true = open
+`sensor_presence`    |                      | Motion sensor or some other way of presence detection. true = presence
 
 #### Interfaces
 
 Type | Interface           | Value type | Description
 -----|---------------------|------------|--------------------
-out  | evt.open.report     | bool       | true - contact is open (window/door is open), false - contact is closed.
+out  | evt.open.report     | bool       |
 in   | cmd.open.get_report | null       |
-
-***
-
-### Presence sensor service
-
-Motion sensor or some other way of presence detection.
-
-#### Service names
-
-`sensor_presence`
-
-#### Interfaces
-
-Type | Interface               | Value type | Description
------|-------------------------|------------|--------------------
-out  | evt.presence.report     | bool       | true - presence detected.
-in   | cmd.presence.get_report | null       |
 
 ***
 
@@ -522,8 +506,8 @@ Topic example: `pt:j1/mt:evt/rt:dev/rn:zw/ad:1/sv:berier_ctrl/ad:15_0`
 
 Name           | Value example         | Description
 ---------------|-----------------------|-------------
-sup_states     | open, closed, closing |  supported states
-sup_tstates    | open, close           |  supported target states
+sup_states     | open, closed, closing | supported states
+sup_tstates    | open, close           | supported target states
 sup_notiftypes | audio, visual         | supported notifications types, like siren, flashlight
 
 ### Complex alarm system service

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Topic example: `pt:j1/mt:cmd/rt:dev/rn:zw/ad:1/sv:out_bin_switch/ad:15_0`
 
 ***
 
-### Output binary switch service
+### Output level switch service
 
 Used for dimmers and things generally controlled with sliders.
 
@@ -122,7 +122,7 @@ in   | cmd.lvl.set        | int        | duration            | props = {"duratio
 in   | cmd.lvl.start      | string     | start_lvl, duration | Start a level change. Value defines direction can be: up, down, auto
 in   | cmd.lvl.stop       | null       |                     | Stop a level change
 in   | cmd.lvl.get_report | null       |                     |
-in   | cmd.binary.set     | bool       |                     | true is mapped t 255, false to 0
+in   | cmd.binary.set     | bool       |                     | true is mapped to 255, false to 0
 out  | evt.binary.report  | bool       |                     |
 
 Topic example: `pt:j1/mt:cmd/rt:dev/rn:zw/ad:1/sv:out_lvl_switch/ad:15_0`

--- a/README.md
+++ b/README.md
@@ -115,25 +115,32 @@ Used for dimmers and things generally controlled with sliders.
 
 #### Interfaces
 
-Type | Interface          | Value type | Properties          | Description
------|--------------------|------------|---------------------|------------
-out  | evt.lvl.report     | int        |                     |
-in   | cmd.lvl.set        | int        | duration            | props = {"duration":"5"}. Duration is in seconds, factory default is used is propery is not defined.
-in   | cmd.lvl.start      | string     | start_lvl, duration | Start a level change. Value defines direction can be: up, down, auto
-in   | cmd.lvl.stop       | null       |                     | Stop a level change
-in   | cmd.lvl.get_report | null       |                     |
-in   | cmd.binary.set     | bool       |                     | true is mapped to 255, false to 0
-out  | evt.binary.report  | bool       |                     |
+Type | Interface          | Value type | Properties              | Description
+-----|--------------------|------------|-------------------------|------------
+out  | evt.lvl.report     | int        |                         |
+in   | cmd.lvl.set        | int        | `duration`              |
+in   | cmd.lvl.start      | string     | `start_lvl`, `duration` |
+in   | cmd.lvl.stop       | null       |                         | Stop a level change
+in   | cmd.lvl.get_report | null       |                         |
+in   | cmd.binary.set     | bool       |                         | true is mapped to 255, false to 0
+out  | evt.binary.report  | bool       |                         |
 
 Topic example: `pt:j1/mt:cmd/rt:dev/rn:zw/ad:1/sv:out_lvl_switch/ad:15_0`
 
-#### Props
+#### Interface props
 
-Name    | Value example   | Description
---------|-----------------|-------------
-min_lvl | 0               | minimum value
-max_lvl | 99              | maximum value
-sw_type | on_off, up_down | type of level switch
+Name        | Value example | Description
+------------|---------------|-------------
+`duration`  | "10"          | duration in seconds. Factory default is used if no value is provided.
+`start_lvl` | "up"          | level change direction. Supported values are `up`, `down` and `auto`.
+
+#### Service props
+
+Name      | Value example | Description
+----------|---------------|-------------
+`min_lvl` | 0             | minimum value.
+`max_lvl` | 99            | maximum value.
+`sw_type` | "on_off"      | type of level switch. Supported values are "on_off" or "up_down".
 
 ***
 
@@ -147,19 +154,27 @@ Service name  | Units                                     | Description
 ------------- |-------------------------------------------|------------
 `meter_elec`  | kWh, kVAh, W, pulse_c, V, A, power_factor | Electric meter
 `meter_gas`   | cub_m, cub_f, pulse_c                     | Gas meter
-`meter_water` | cub_m, cub_f, gallon, pulse_c              | Water meter
+`meter_water` | cub_m, cub_f, gallon, pulse_c             | Water meter
 
 #### Interfaces
 
 Type | Interface            | Value type | Properties              | Description
 -----|----------------------|------------|-------------------------|-------------
-out  | evt.meter.report     | float      | unit, prv_data, delta_t | prv_data - previous meter reading, delta_t - time delta
+out  | evt.meter.report     | float      | unit, prv_data, delta_t |
 in   | cmd.meter.reset      | null       |                         | Resets all historical readings.
-in   | cmd.meter.get_report | string     |                         | Value - is a unit. May not be supported by all meter.
+in   | cmd.meter.get_report | string     |                         | Value - is a unit. May not be supported by all meters.
 
 Topic example: `pt:j1/mt:evt/rt:dev/rn:zw/ad:1/sv:meter_elec/ad:15_0`
 
-#### Props
+#### Interface props
+
+Name     | Value example | Description
+---------|---------------|-------------
+unit     |               |
+prv_data |               | previous meter reading
+delta_t  |               | time delta
+
+#### Service props
 
 Name      | Value example          | Description
 ----------|------------------------|-------------
@@ -217,7 +232,7 @@ in   | cmd.sensor.get_report | string     |            | Value is desired unit. 
 
 Example message: [evt.sensor.report](json-v1/messages/examples/evt.sensor.report)
 
-#### Props
+#### Service props
 
 Name      | Value example | Description
 ----------|---------------|-------------
@@ -229,10 +244,10 @@ sup_units | ["C", "F"]    | list of supported units.
 
 #### Service names
 
-Service name         | Units                | Description
----------------------|----------------------|------------
-`sensor_contact`     |                      | Binary contact sensor, normally magnetic contact. true = open
-`sensor_presence`    |                      | Motion sensor or some other way of presence detection. true = presence
+Service name         | Units | Description
+---------------------|-------|------------
+`sensor_contact`     |       | Binary contact sensor, normally magnetic contact. true = open
+`sensor_presence`    |       | Motion sensor or some other way of presence detection. true = presence
 
 #### Interfaces
 
@@ -276,7 +291,7 @@ Supported statuses: activ, deactiv. IMPORTANT: These are shorthands for "activat
 
 Example message: [evt.sensor.report](json-v1/messages/examples/evt.alarm.report.json)
 
-#### Props
+#### Service props
 
 Name       | Value example           | Description
 -----------|-------------------------|-------------
@@ -294,9 +309,15 @@ sup_events | ["smoke", "smoke_test"] | supported events.
 
 Type | Interface          | Value type | Properties | Description
 -----|--------------------|------------|----------- |------------------
-out  | evt.lvl.report     | int        | state      | available states: charging, charged, replace, emtpy
+out  | evt.lvl.report     | int        | state      |
 out  | evt.alarm.report   | str_map    |            | val = {"event": "low_battery", "status": "activ"}
 in   | cmd.lvl.get_report | null       |            | Get battery level over level report.
+
+#### Interface props
+
+Name  | Value example | Description
+------|---------------|-------------
+state | "charging"    | available states: charging, charged, replace, emtpy
 
 ### Thermostat service
 
@@ -317,7 +338,7 @@ out  | evt.mode.report         | string     |
 out  | evt.state.report        | string     |  Reports operational state.
 in   | cmd.state.get_report    | null       |
 
-#### Props
+#### Service props
 
 Name           | Value example                                                                  | Description
 ---------------|--------------------------------------------------------------------------------|-------------
@@ -339,12 +360,19 @@ Set-point types: heat, cool, furnace, dry_air, moist_air, auto_changeover, energ
 
 Type | Interface               | Value type | Properties           | Description
 -----|-------------------------|------------|----------------------|------------------
-out  | evt.lock.report         | bool_map   | timeout_s, lock_type | value = {"is_secured":true, "door_is_closed":true, "bolt_is_locked":true, "latch_is_closed":true}, lock_type properties reports how lock was locked or unlocked, it can take values: "key", "pin", "rfid"
+out  | evt.lock.report         | bool_map   | timeout_s, lock_type | value = {"is_secured":true, "door_is_closed":true, "bolt_is_locked":true, "latch_is_closed":true}
 in   | cmd.lock.set            | bool       |                      | Use true to secure a lock and false to unsecure
 in   | cmd.lock.set_with_code  | str_map    |                      | Used to lock/unlock locks required PIN/RFID, {“op”:”lock”, ”code_type”:”pin”, ”12345” }
 in   | cmd.lock.get_report     | null       |                      |
 
-#### Props
+#### Interface props
+
+Name      | Value example | Description
+----------|---------------|-------------
+timeout_s |               |
+lock_type | "key"         | how lock was activated, it can take values: "key", "pin", "rfid"
+
+#### Service props
 
 Name           | Value example                                                         | Description
 ---------------|-----------------------------------------------------------------------|-------------
@@ -366,7 +394,7 @@ in   | cmd.usercode.get_config_report | str_map    | {"user_id":"123", "code_typ
 in   | cmd.usercode.clear_all         | null       | Clear all codes
 in   | cmd.usercode.clear             | str_map    | {"user_id":"123", "code_type":"rfid"}, code type should be either "all" or one of supported types
 
-#### Props
+#### Service props
 
 Name           | Value example              | Description
 ---------------|----------------------------|-------------
@@ -390,7 +418,7 @@ in   | cmd.color.set        | int_map    | value is a map of color components. v
 in   | cmd.color.get_report | null       | The command is a request for a map of color component values
 out  | evt.color.report     | int_map    | Map of color components, where value is component intensity.
 
-#### Props
+#### Service props
 
 Name           | Value example            | Description
 ---------------|--------------------------|-------------
@@ -421,7 +449,7 @@ in   | cmd.scene.get_report | null       | The command is a request for current 
 in   | cmd.scene.set        | string     | Set scene
 out  | evt.scene.report     | string     | Event is generated whenever scene button is pressed on controller.
 
-#### Props
+#### Service props
 
 Name       | Value example | Description
 -----------|---------------|-------------
@@ -451,7 +479,7 @@ in   | cmd.modelvl.set        | int_map    | val = {"mid":90, "auto_low":10}
 in   | cmd.modelvl.get_report | string     | The command is a request for fan speed level for particular mode. If mode is set to "", the device should report levels for all modes.
 out  | evt.modelvl.report     | int_map    | val = {"mid":90, "auto_low":10}
 
-#### Props
+#### Service props
 
 Name       | Value example      | Description
 -----------|--------------------|-------------
@@ -474,11 +502,11 @@ in   | cmd.mode.get_report | null       |
 
 Topic example: `pt:j1/mt:evt/rt:dev/rn:zw/ad:1/sv:siren_ctrl/ad:15_0`
 
-#### Props
+#### Service props
 
 Name           | Value example       | Description
 ---------------|---------------------|-------------
-sup_modes      | on, off, fire, leak    | List of supported tones
+sup_modes      | on, off, fire, leak | List of supported tones
 
 ### Barrier control service
 
@@ -502,7 +530,7 @@ out  | evt.notiftype.report     | bool_map   |
 
 Topic example: `pt:j1/mt:evt/rt:dev/rn:zw/ad:1/sv:berier_ctrl/ad:15_0`
 
-#### Props
+#### Service props
 
 Name           | Value example         | Description
 ---------------|-----------------------|-------------

--- a/README.md
+++ b/README.md
@@ -1,513 +1,559 @@
-# Futurehome IoT Messaging Protocol - FIMP 
-
+# Futurehome IoT Messaging Protocol - FIMP
 
 ## Service overview.
-In FIMP every device/app functionality is represented as service , every service should have at least one interface and at least one attribute . A service interacts with outer world by means of messages , it can either produce messages (events) , receive messages (commands) but also in some cases it may send command . Each service has its own unique address (topic) , all interfaces within the service share the same address . A service can't have more than one interface of the same type. 
-Abstract diagram : 
 
-![Fimp Service overview](static/fimp-service.png) 
+In FIMP, every device / app-functionality is represented as service. Every service should have at least one interface and at least one attribute. A service interacts with outer world by means of messages, it can either produce messages (events), receive messages (commands) but also in some cases it may send command. Each service has its own unique address (topic), all interfaces within the service share the same address. A service can't have more than one interface of the same type.
 
+Abstract diagram:
 
-Device example :
+![Fimp Service overview](static/fimp-service.png)
 
-![Fimp Service overview](static/fimp-thing-example.png) 
+Device example:
 
-Message format :
+![Fimp Service overview](static/fimp-thing-example.png)
 
-[FIMP message format ](message-format.md) 
+Message format:
 
+[FIMP message format](message-format.md)
 
-## Component discovery mechanism.  
+## Component discovery mechanism.
 
-The mechanism allows dynamically discover different system component like adapters and application .  
+The mechanism allows dynamically discover different system component like adapters and application.
 
-[Component discovery flow and messages ](component-discovery.md) 
+[Component discovery flow and messages ](component-discovery.md)
 
-## Adding / removing things to FH system. 
+## Adding / removing things to FH system.
 
-Things can be added to FH ecosystem in 2 ways :
+Things can be added to FH ecosystem in 2 ways:
 
 1. [Adding/removing a thing to FH system via adapter](thing-management.md)
 2. [Connecting/disconnecting a system to FH system](system-management.md)
 
-First method should be used to add a thing which isn't paired with underlying RF module , for instance: Z-Wave , Zigbee , Bluetooth 
- 
-Second method should be used to connect a system which already has a number of connected devices , for instance: Ikea Tradfri , Philips Hue , Sonos , etc. 
+First method should be used to add a thing which isn't paired with underlying RF module, for instance: Z-Wave, Zigbee, Bluetooth
 
-Example : add zwave device , remove zwave device , add zigbee device , remove zigbee device .
+Second method should be used to connect a system which already has a number of connected devices, for instance: IKEA Trådfri, Phillips Hue, Sonos, etc.
 
-## Services.
+Example: add z-wave device, remove z-wave device, add zigbee device, remove zigbee device.
 
-#### Basic service 
-Service name : **basic**
+## Services
 
-Description  : Meaning of **basic** service can vary from device to device . It's generic and most simple way to interact with a device . 
+### Basic service
 
-Type  | Interface                | Value type | Description 
-------|--------------------------|------------|------------
-out   | evt.lvl.report           | int        | Reports level using numeric value 
-in    | cmd.lvl.set              | int        | Sets level using numeric value 
-in    | cmd.lvl.get_report       | null       | 
+A generic service and the most simple way to interact with a device. The actual meaning of "basic" varies from device to device.
 
-Topic example : `pt:j1/mt:evt/rt:dev/rn:zw/ad:1/sv:basic/ad:15_0`
+#### Service names
 
-***
+`basic`
 
-#### Device/Thing system service 
-Service name : **dev_sys**
+#### Interfaces
 
-Type  | Interface                  | Value type | Description 
-------|----------------------------|------------|------------
-out   | evt.config.report          | str_map    | Reports configurations in form of key-value pairs . 
-in    | cmd.config.set             | str_map    | Sets configuration . Value is a key-value pairs.
-in    | cmd.config.get_report      | str_array  | Requests service to respond with config report . If array is empty - report all parameters .
-in    | cmd.config.get_supp_list   | null       | Requests service to respond with a list of supported configurations . 
-in    | cmd.config.supp_list_report| str_map    | List of supported configurations . Key - config name , value - short description. 
-out   | evt.group.members_report   | object     | Object structure {"group":"group1","members":["node1","node2"]} 
-in    | cmd.group.add_members      | object     | Adds members to the group. Object has the same format as members_report
-in    | cmd.group.delete_members   | object     | Object has the same format as report. 
-in    | cmd.group.get_members      | string     | Value is a group name . 
+Type | Interface          | Value type | Description
+-----|--------------------|------------|------------
+out  | evt.lvl.report     | int        | Reports level using numeric value
+in   | cmd.lvl.set        | int        | Sets level using numeric value
+in   | cmd.lvl.get_report | null       |
 
-*Notes:*
-> z-wave configuration values should be in form <value>;size , for instance 12;2
-
-> z-wave association memeber should be in form <node_id>_<endpoint_id> , for instance 10_0 
+Topic example: `pt:j1/mt:evt/rt:dev/rn:zw/ad:1/sv:basic/ad:15_0`
 
 ***
 
-#### Output binary switch service 
+### System related device service
 
-Service name : **out_bin_switch** 
+#### Service names
 
-Description  : Wallplugs , relays , simple sirens , etc should be controlled over the service. 
+`dev_sys`
 
-Type  | Interface                | Value type | Description 
-------|--------------------------|------------|------------ 
-out   | evt.binary.report        | bool       | Reports true when switch is ON and false whenr switch is OFF 
-in    | cmd.binary.set           | bool       | 
-in    | cmd.binary.get_report    | null       | 
+#### Interfaces
 
-Topic example : `pt:j1/mt:cmd/rt:dev/rn:zw/ad:1/sv:out_bin_switch/ad:15_0`
+Type  | Interface                   | Value type | Description
+------|---------------------------- |------------|------------
+out   | evt.config.report           | str_map    | Reports configurations in form of key-value pairs.
+in    | cmd.config.set              | str_map    | Sets configuration. Value is a key-value pairs.
+in    | cmd.config.get_report       | str_array  | Requests service to respond with config report. If array is empty - report all parameters.
+in    | cmd.config.get_supp_list    | null       | Requests service to respond with a list of supported configurations.
+in    | cmd.config.supp_list_report | str_map    | List of supported configurations. Key - config name, value - short description.
+out   | evt.group.members_report    | object     | Object structure {"group":"group1", "members":["node1", "node2"]}
+in    | cmd.group.add_members       | object     | Adds members to the group. Object has the same format as members_report
+in    | cmd.group.delete_members    | object     | Object has the same format as report.
+in    | cmd.group.get_members       | string     | Value is a group name.
 
-***
+#### Notes
 
-#### Output level switch service 
+- z-wave configuration values should be in form <value>;size, for instance 12;2
 
-Service name : **out_lvl_switch** 
-
-Description  :  
-
-Type  | Interface                | Value type | Properties                | Description 
-------|--------------------------|------------|---------------------------|------------ 
-out   | evt.lvl.report           | int        |                           |
-in    | cmd.lvl.set              | int        | duration                  | props = {"duration":"5"} . Duration is in seconds , factory default is used is propery is not defined .  
-in    | cmd.lvl.start            | string     | start_lvl,duration        | Start a level change. Value defines direction can be : up,down,auto 
-in    | cmd.lvl.stop             | null       |                           | Stop a level change 
-in    | cmd.lvl.get_report       | null       |                           |
-in    | cmd.binary.set           | bool       |                           | true is mapped t 255 , false to 0
-out		 |	evt.binary.report		      |	bool       |                           |
-
-Descriptor properties : 
-
-Name      | Value example   | Description 
-----------|-----------------|-------------
-min_lvl   | 0               | minimum value 
-max_lvl   | 99              | maximum value 
-sw_type   | on_off,up_down  | type of level switch
-
- 
-Topic example : `pt:j1/mt:cmd/rt:dev/rn:zw/ad:1/sv:out_lvl_switch/ad:15_0`
+- z-wave association member should be in form <node_id>\_<endpoint_id>, for instance 10_0
 
 ***
 
-#### Meter service 
-Service name : Refer to the table below.
+### Output binary switch service
 
-Description  : Meters report consumption over the sevice . 
+Output binary switch service for wall-plugs, relays, simple sirens, etc.
 
-Type  | Interface                | Value type | Properties                | Description 
-------|--------------------------|------------|---------------------------|------------- 
-out   | evt.meter.report         | float      | unit , prv_data , delta_t | prv_data - previous meter reading , delta_t - time delta 
-in    | cmd.meter.reset          | null       |                           | Resets all historical readings . 
-in    | cmd.meter.get_report     | string     |                           | Value - is a unit . May not be supported by all meter .
+#### Service names
 
-Supported meter types and their units : 
+`out_bin_switch`
 
-Service name       | Units                               | Description 
- ------------------|-------------------------------------|------------
- meter_elec        | kWh,kVAh,W,pulse_c,V,A,power_factor | Electric meter 
- meter_gas         | cub_m,cub_f,pulse_c                 | Gas meter 
- meter_water       | cub_m,cub_f,galon,pulse_c           | Water meter 
+#### Interfaces
 
-Topic example : `pt:j1/mt:evt/rt:dev/rn:zw/ad:1/sv:meter_elec/ad:15_0`
+Type  | Interface             | Value type | Description
+------|-----------------------|------------|------------
+out   | evt.binary.report     | bool       | Reports true when switch is ON and false when switch is OFF
+in    | cmd.binary.set        | bool       |
+in    | cmd.binary.get_report | null       |
 
-Descriptor properties : 
+Topic example: `pt:j1/mt:cmd/rt:dev/rn:zw/ad:1/sv:out_bin_switch/ad:15_0`
 
-Name      | Value example       | Description 
+***
+
+### Output binary switch service
+
+Used for dimmers and things generally controlled with sliders.
+
+#### Service names
+
+`out_lvl_switch`
+
+#### Interfaces
+
+Type  | Interface          | Value type | Properties          | Description
+------|--------------------|------------|---------------------|------------
+out   | evt.lvl.report     | int        |                     |
+in    | cmd.lvl.set        | int        | duration            | props = {"duration":"5"}. Duration is in seconds, factory default is used is propery is not defined.
+in    | cmd.lvl.start      | string     | start_lvl, duration | Start a level change. Value defines direction can be: up, down, auto
+in    | cmd.lvl.stop       | null       |                     | Stop a level change
+in    | cmd.lvl.get_report | null       |                     |
+in    | cmd.binary.set     | bool       |                     | true is mapped t 255, false to 0
+out   | evt.binary.report  | bool       |                     |
+
+Topic example: `pt:j1/mt:cmd/rt:dev/rn:zw/ad:1/sv:out_lvl_switch/ad:15_0`
+
+#### Props
+
+Name      | Value example    | Description
+----------|------------------|-------------
+min_lvl   | 0                | minimum value
+max_lvl   | 99               | maximum value
+sw_type   | on_off, up_down  | type of level switch
+
+***
+
+### Meter services
+
+Meters report consumption over the service.
+
+#### Service names
+
+Service name  | Units                                     | Description
+------------- |-------------------------------------------|------------
+`meter_elec`  | kWh, kVAh, W, pulse_c, V, A, power_factor | Electric meter
+`meter_gas`   | cub_m, cub_f, pulse_c                     | Gas meter
+`meter_water` | cub_m, cub_f, galon, pulse_c              | Water meter
+
+#### Interfaces
+
+Type  | Interface                | Value type | Properties                | Description
+------|--------------------------|------------|---------------------------|-------------
+out   | evt.meter.report         | float      | unit, prv_data, delta_t | prv_data - previous meter reading, delta_t - time delta
+in    | cmd.meter.reset          | null       |                           | Resets all historical readings.
+in    | cmd.meter.get_report     | string     |                           | Value - is a unit. May not be supported by all meter.
+
+Topic example: `pt:j1/mt:evt/rt:dev/rn:zw/ad:1/sv:meter_elec/ad:15_0`
+
+#### Props
+
+Name      | Value example       | Description
 ----------|---------------------|-------------
-sup_units | ["W","kWh","A","V"] | list of supported units .
+sup_units | ["W", "kWh", "A", "V"] | list of supported units.
 
 ***
 
-#### Numeric sensor service 
-Service name : Refer to the table below . 
-  
-Description :  
+### Numeric sensor services
 
- Type  | Interface                | Value type | Properties                | Description 
--------|--------------------------|------------|---------------------------|------------- 
-out    | evt.sensor.report        | float      | unit                      | 
-in     | cmd.sensor.get_report    | string     |                           | Value is desired unit. Use empty value to get report in default unit .   
+#### Service names
 
- Supported sensor type and their units :
+Service name         | Units                    | Description
+---------------------|--------------------------|------------
+`sensor_accelx`      | m/s2                     | Acceleration, X-axis
+`sensor_accely`      | m/s2                     | Acceleration, Y-axis
+`sensor_accelz`      | m/s2                     | Acceleration, Z-axis
+`sensor_airflow`     | m3/h, ft3/m              | Air flow sensor
+`sensor_anglepos`    | %, degN, degS            | Angle Position sensor
+`sensor_atmo`        | kPa, ha                  | Atmospheric pressure sensor. ha - inches of Mercury
+`sensor_baro`        | kPa, ha                  | Barometric  pressure sensor. ha - inches of Mercury
+`sensor_co2`         | ppm                      | CO2-level sensor
+`sensor_co`          | mol/m3                   | Carbon Monoxide level sensor
+`sensor_current`     | A, mA                    | Current sensor
+`sensor_dew`         | C, F                     | Dew point sensor
+`sensor_direct`      | deg                      | Direction sensor
+`sensor_distance`    | m, cm, ft                | Distance sensor
+`sensor_elresist`    | ohm/m                    | Electrical resistivity sensor
+`sensor_freq`        | Hz, kHz                  | Frequency sensor
+`sensor_gp`          | %, NOM                   | General purpose sensor
+`sensor_humid`       | %, g/m3                  | Relative humidity sensor
+`sensor_lumin`       | Lux, %                   | Luminance sensor
+`sensor_moist`       | %, kOhm, m3/m3, aw       | Moisture sensor
+`sensor_power`       | W, Btu/h                 | Power sensor. Btu/h - British thermal unit per hour
+`sensor_rain`        | mm/h, in/h               | Rain rate sensor
+`sensor_rotation`    | rpm, Hz                  | Rotation sensor
+`sensor_seismicint`  | EMCRO, LEIDO, MERC, SHDO | Seismic intensity sensor
+`sensor_seismicmag`  | MB, ML, MW, MS           | Seismic magnitude sensor
+`sensor_solarrad`    | w/m2                     | Solar radiation
+`sensor_tank`        | l, gal, m3               | Tank capacity sensor
+`sensor_temp`        | C, F                     | Temperature sensor
+`sensor_tidelvl`     | m, ft                    | Tide level sensor
+`sensor_uv`          | index                    | Ultraviolet sensor
+`sensor_veloc`       | m/s, mph                 | Velocity sensor
+`sensor_voltage`     | V, mV                    | Voltage sensor
+`sensor_watflow`     | l/h                      | Water flow sensor
+`sensor_watpressure` | kPa                      | Water pressure sensor
+`sensor_weight`      | kg, lbs                  | Weight sensor
 
- Service name       | Units                 | Description 
- -------------------|-----------------------|------------
- sensor_temp        | C, F                  | Temperature sensor
- sensor_gp          | % , NOM               | General purpose sensor  
- sensor_lumin       | Lux , %               | Luminance sensor
- sensor_power       | W,Btu/h               | Power sensor . Btu/h - British thermal unit per hour
- sensor_humid       | %,g/m3                | Relative humidity sensor
- sensor_veloc       | m/s,mph               | Velocity sensor
- sensor_direct      | deg                   | Direction sensor
- sensor_atmo        | kPa,ha                | Atmospheric pressure sensor . ha - inches of Mercury
- sensor_baro        | kPa,ha                | Barometric  pressure sensor . ha - inches of Mercury
- sensor_solarrad    | w/m2                  | Solar radiation
- sensor_dew         | C, F                  | Dew point sensor
- sensor_rain        | mm/h,in/h             | Rain rate sensor
- sensor_tidelvl     | m, ft                 | Tide level sensor
- sensor_weight      | kg, lbs               | Weight sensor
- sensor_voltage     | V, mV                 | Voltage sensor
- sensor_current     | A, mA                 | Current sensor
- sensor_co2         | ppm                   | CO2-level sensor
- sensor_co          | mol/m3                | Carbon Monoxide level sensor
- sensor_airflow     | m3/h,ft3/m            | Air flow sensor
- sensor_tank        | l,gal,m3              | Tank capacity sensor
- sensor_distance    | m,cm,ft               | Distance sensor
- sensor_anglepos    | %,degN,degS           | Angle Position sensor
- sensor_rotation    | rpm,Hz                | Rotation sensor
- sensor_seismicint  | EMCRO,LEIDO,MERC,SHDO | Seismic intensity sensor
- sensor_seismicmag  | MB,ML,MW,MS           | Seismic magnitude sensor
- sensor_uv          | index                 | Ultraviolet sensor
- sensor_elresist    | ohm/m                 | Electrical resistivity sensor
- sensor_moist       | %,kOhm,m3/m3,aw       | Moisture sensor
- sensor_freq        | Hz,kHz                | Frequency sensor
- sensor_accelx      | m/s2                  | Acceleration, X-axis
- sensor_accely      | m/s2                  | Acceleration, Y-axis
- sensor_accelz      | m/s2                  | Acceleration, Z-axis
- sensor_accelz      | m/s2                  | Acceleration, Z-axis
- sensor_watflow     | l/h                   | Water flow sensor
- sensor_watpressure | kPa                   | Water pressure sensor
+#### Interfaces
 
-Example message : [evt.sensor.report](json-v1/messages/examples/evt.sensor.report)
+Type   | Interface                | Value type | Properties                | Description
+-------|--------------------------|------------|---------------------------|-------------
+out    | evt.sensor.report        | float      | unit                      |
+in     | cmd.sensor.get_report    | string     |                           | Value is desired unit. Use empty value to get report in default unit.
 
-Descriptor properties : 
+Example message: [evt.sensor.report](json-v1/messages/examples/evt.sensor.report)
 
-Name      | Value example   | Description 
-----------|-----------------|-------------
-sup_units | ["C","F"]       | list of supported units .
+#### Props
+
+Name      | Value example    | Description
+----------|------------------|-------------
+sup_units | ["C", "F"]       | list of supported units.
 
 ***
 
-#### Contact sensor service 
-Service name : **sensor_contact** . 
-  
-Description : Binary contact sensor , normally magnetic contact .
+### Contact sensor service
 
- Type  | Interface                | Value type | Description 
--------|--------------------------|------------|-------------------- 
-out    | evt.open.report          | bool       | true - contact is open (window/door is open) , false - contact is closed .
-in     | cmd.open.get_report      | null       |    
+Binary contact sensor, normally magnetic contact.
 
-***
+#### Service names
 
-#### Presence sensor service 
-Service name : **sensor_presence** . 
-  
-Description : Motion sensor or some other way of presence detection .
+`sensor_contact`
 
- Type  | Interface                | Value type | Description 
--------|--------------------------|------------|-------------------- 
-out    | evt.presence.report      | bool       | true - presence detected .
-in     | cmd.presence.get_report  | null       |    
+#### Interfaces
+
+Type   | Interface           | Value type | Description
+-------|---------------------|------------|--------------------
+out    | evt.open.report     | bool       | true - contact is open (window/door is open), false - contact is closed.
+in     | cmd.open.get_report | null       |
 
 ***
 
-#### Alarm services 
-Service name : Refer to the table below 
+### Presence sensor service
 
-Description : 
+Motion sensor or some other way of presence detection.
 
-Type   | Interface                | Value type | Description 
--------|--------------------------|------------|-------------------- 
-out    | evt.alarm.report         | str_map    | val = {"event": "tamper_removed_cover","status": "activ"} 
-in     | cmd.alarm.get_report     | ?          |    
+#### Service names
 
-Supported alarm types : 
+> Service name: `sensor_presence`
 
- Service name      | Event                                   | Description 
--------------------|-----------------------------------------|------------
-alarm_fire         | smoke ,smoke_test                       |
-alarm_heat         | overheat,temp_rise,underheat            |
-alarm_gas          | CO,CO2, combust_gas_detected            |
-   alarm_gas       | toxic_gas_detected ,test,replace        |
-alarm_water        | leak, level_drop, replace_filter        |
-alarm_lock         | manual_lock,rf_lock,keypad_lock,        | TODO: move to doorlock service
-   alarm_lock      | manual_not_locked, rf_not_locked        |
-   alarm_lock      | auto_locked , jammed                    |
-alarm_burglar      | intrusion,tamper_removed_cover,         |
-   alarm_burglar   | tamper_invalid_code,glass_breakage      |
-alarm_power        | on,ac_on,ac_off,surge,voltage_drop,     | TODO: move to power_supply service
-   alarm_power     | over_current,over_voltage,              |
-   alarm_power     | replace_soon,replace_now,charging,      |
-   alarm_power     | charged,charge_soon,charge_now          | 
-alarm_system       | hw_failure,sw_failure,                  | 
-   alarm_system    | hw_failure_with_code,                   | 
-   alarm_system    | sw_failure_with_code                    | 
-alarm_emergency    | police,fire,medical                     | 
-alarm_time         | wakeup,timer_ended,time_remaining       | 
-alarm_applience    | program_started,program_inprogress,     | 
-  alarm_applience  | program_completed,replace_filter ,      | 
-  alarm_applience  | set_temp_error,supplying_water,         | 
-  alarm_applience  | water_supply_err, boiling,              | 
-  alarm_applience  | boiling_err,washing,washing_err         | 
-  alarm_applience  | rinsing,rinsing_err,draining ,          | 
-  alarm_applience  | draining_err,spinnning,spinning_err,    | 
-  alarm_applience  | drying,drying_err,fan_err,              | 
-  alarm_applience  | compressor_err                          | 
-alarm_health       | leaving_bed,sitting_on_bed,lying_on_bed,| 
-  alarm_health     | posture_change,sitting_on_bed_edge,     | 
-  alarm_health     | volatile_organic_compound               | 
-alarm_siren        | inactive,siren_active                   | 
-alarm_water_valve  | valve_op,master_valve_op,               | 
-  alarm_water_valve| valve_short_circuit,current_alarm       | 
-  alarm_water_valve| master_valve_current_alarm              | 
- alarm_weather     | inactive,moisture                       | 
+#### Interfaces
 
-Example message : [evt.sensor.report](json-v1/messages/examples/evt.alarm.report.json)
-
-Supported statuses : activ,deactiv
-
-Descriptor properties : 
-
-Name       | Value example          | Description 
------------|------------------------|-------------
-sup_events | ["smoke","smoke_test"] | supported events .
+Type   | Interface                | Value type | Description
+-------|--------------------------|------------|--------------------
+out    | evt.presence.report      | bool       | true - presence detected.
+in     | cmd.presence.get_report  | null       |
 
 ***
 
-#### Battery service
-Service name : **battery** . 
-  
-Description :  
+### Alarm services
 
- Type  | Interface                | Value type | Properties| Description 
--------|--------------------------|------------|-----------|------------------ 
-out    | evt.lvl.report           | int        | state     | available states : charging,charged,replace,emtpy
-out    | evt.alarm.report         | str_map    |           | val = {"event": "low_battery","status": "activ"}   
-in     | cmd.lvl.get_report       | null       |           | Get battery level over level report . 
-   
-#### Thermostat service
-Service name : **thermostat** . 
-  
-Description :  
+#### Service names
 
- Type  | Interface                  | Value type | Properties| Description 
--------|----------------------------|------------|-----------|------------------ 
-out    | evt.setpoint.report        | str_map    |           | val = {"type":"heat","temp":"21.5","unit":"C"}   
-in     | cmd.setpoint.set           | str_map    |           | val = {"type":"heat","temp":"21.5","unit":"C"} 
-in     | cmd.setpoint.get_report    | string     |           | value is a setpoint type 
-in     | cmd.mode.set               | string     |           |  Set thermostat mode :
-in     | cmd.mode.get_report        | null       |           |  
-out    | evt.mode.report            | string     |           |  
-out    | evt.state.report           | string     |           |  Reports operational state .
-in     | cmd.state.get_report       | null       |           |  
-   
+Service name         | Event                                   | Description
+---------------------|-----------------------------------------|------------
+`alarm_fire`         | smoke, smoke_test                       |
+`alarm_heat`         | overheat, temp_rise, underheat          |
+`alarm_gas`          | CO, CO2, combust_gas_detected, toxic_gas_detected, test, replace |
+`alarm_water`        | leak, level_drop, replace_filter        |
+`alarm_lock`         | manual_lock, rf_lock, keypad_lock, manual_not_locked, rf_not_locked, auto_locked, jammed | TODO: move to doorlock service
+`alarm_burglar`      | intrusion, tamper_removed_cover, alarm_burglar, tamper_invalid_code, glass_breakage |
+`alarm_power`        | on, ac_on, ac_off, surge, voltage_drop, over_current, over_voltage, replace_soon, replace_now, charging, charged, charge_soon, charge_now | TODO: move to power_supply service
+`alarm_system`       | hw_failure, sw_failure, hw_failure_with_code, sw_failure_with_code |
+`alarm_emergency`    | police, fire, medical                   |
+`alarm_time`         | wakeup, timer_ended, time_remaining     |
+`alarm_applience`    | program_started, program_inprogress, program_completed, replace_filter, set_temp_error, supplying_water, water_supply_err, boiling, boiling_err, washing, washing_err, rinsing, rinsing_err, draining, draining_err, spinnning, spinning_err, drying, drying_err, fan_err, compressor_err |
+`alarm_health`       | leaving_bed, sitting_on_bed, lying_on_bed, alarm_health, posture_change, sitting_on_bed_edge, alarm_health, volatile_organic_compound |
+`alarm_siren`        | inactive, siren_active                  |
+`alarm_water_valve`  | valve_op, master_valve_op, alarm_water_valve, valve_short_circuit, current_alarm, alarm_water_valve, master_valve_current_alarm |
+`alarm_weather`      | inactive, moisture                      |
 
-Descriptor properties : 
+#### Interfaces
 
-Name           | Value example       | Description 
+Type   | Interface                | Value type | Description
+-------|--------------------------|------------|--------------------
+out    | evt.alarm.report         | str_map    | val = {"event": "tamper_removed_cover", "status": "activ"}
+in     | cmd.alarm.get_report     | ?          |
+
+Supported statuses: activ, deactiv
+
+Example message: [evt.sensor.report](json-v1/messages/examples/evt.alarm.report.json)
+
+#### Props
+
+Name       | Value example           | Description
+-----------|-------------------------|-------------
+sup_events | ["smoke", "smoke_test"] | supported events.
+
+***
+
+### Battery service
+
+#### Service names
+
+`battery`
+
+#### Interfaces
+
+ Type  | Interface          | Value type | Properties | Description
+-------|--------------------|------------|----------- |------------------
+out    | evt.lvl.report     | int        | state      | available states: charging, charged, replace, emtpy
+out    | evt.alarm.report   | str_map    |            | val = {"event": "low_battery", "status": "activ"}
+in     | cmd.lvl.get_report | null       |            | Get battery level over level report.
+
+### Thermostat service
+
+#### Service names
+
+`thermostat`
+
+#### Interfaces
+
+ Type  | Interface                  | Value type | Properties | Description
+-------|----------------------------|------------|----------- |------------------
+out    | evt.setpoint.report        | str_map    |            | val = {"type":"heat", "temp":"21.5", "unit":"C"}
+in     | cmd.setpoint.set           | str_map    |            | val = {"type":"heat", "temp":"21.5", "unit":"C"}
+in     | cmd.setpoint.get_report    | string     |            | value is a set-point type
+in     | cmd.mode.set               | string     |            |  Set thermostat mode:
+in     | cmd.mode.get_report        | null       |            |
+out    | evt.mode.report            | string     |            |
+out    | evt.state.report           | string     |            |  Reports operational state.
+in     | cmd.state.get_report       | null       |            |
+
+#### Props
+
+Name           | Value example                                                                  | Description
+---------------|--------------------------------------------------------------------------------|-------------
+sup_setpoints  | heat, cool                                                                     | supported set-points.
+sup_modes      | off, heat, cool                                                                | supported modes.
+sup_states     | idle, heat, cool, idle, heat, cool, fan_only, pending_heat, pending_cool, vent |
+
+Modes: off, heat, cool, auto, aux_heat, resume, fan, furnace, dry_air, moist_air, auto_changeover, energy_heat, energy_cool, away.
+
+Set-point types: heat, cool, furnace, dry_air, moist_air, auto_changeover, energy_heat, energy_cool, special_heat,
+
+### Door lock service
+
+#### Service names
+
+`door_lock`
+
+#### Interfaces
+
+ Type  | Interface                | Value type | Properties            | Description
+-------|--------------------------|------------|-----------------------|------------------
+out    | evt.lock.report          | bool_map   | timeout_s, lock_type  | value = {"is_secured":true, "door_is_closed":true, "bolt_is_locked":true, "latch_is_closed":true}, lock_type properties reports how lock was locked or unlocked, it can take values: "key", "pin", "rfid"
+in     | cmd.lock.set             | bool       |                       | Use true to secure a lock and false to unsecure
+in     | cmd.lock.set_with_code   | str_map    |                       | Used to lock/unlock locks required PIN/RFID, {“op”:”lock”, ”code_type”:”pin”, ”12345” }
+in     | cmd.lock.get_report      | null       |                       |
+
+#### Props
+
+Name           | Value example       | Description
 ---------------|---------------------|-------------
-sup_setpoints  | heat,cool     | supported setpoints .
-sup_modes      | off,heat,cool | supported modes .
-sup_states     | idle,heat,cool| idle,heat,cool,fan_only,pending_heat,pending_cool,vent
+sup_components | ["is_secured", "door_is_closed", "bolt_is_locked", "latch_is_closed"]       | List of supported lock component comoponents
 
-Modes : off, heat,cool,auto,aux_heat,resume,fan,furnace,dry_air,moist_air,auto_changeover,energy_heat,energy_cool,away
-Setpoint types : heat,cool,furnace,dry_air,moist_air,auto_changeover,energy_heat,energy_cool,special_heat,
+### User code service
 
-#### Door lock service 
-Service name : **door_lock** . 
-  
-Description : Dorlock 
+Is used by door locks, keypads, security panels to enter and manage pin codes and rfids.
 
- Type  | Interface                | Value type | Properties | Description 
--------|--------------------------|------------|------------|------------------ 
-out    | evt.lock.report          | bool_map   | timeout_s , lock_type  | value = {"is_secured":true,"door_is_closed":true,"bolt_is_locked":true,"latch_is_closed":true} , lock_type properties reports how lock was locked or unlocked , it can take values : "key","pin","rfid"
-in     | cmd.lock.set             | bool       |            | Use true to secure a lock and false to unsecure
-in     | cmd.lock.set_with_code   | str_map    |            | Used to lock/unlock locks required PIN/RFID , {“op”:”lock” ,”code_type”:”pin”,”12345” } 
-in     | cmd.lock.get_report      | null       |            |
+#### Service names
 
-Descriptor properties :
+`user_code`
 
-Name           | Value example       | Description 
+Type   | Interface                      | Value type | Properties | Description
+-------|--------------------------------|------------|------------|------------------
+out    | evt.usercode.config_report     | str_map    |            | {"user_id":"123", "user_status":"enabled", "user_type":"master", "code_type":"rfid", "code":"4321"}
+in     | cmd.usercode.set               | str_map    |            | {"user_id":"123", "user_status":"enabled", "user_type":"master", "code_type":"rfid", "code":"4321"}
+in     | cmd.usercode.get_config_report | str_map    |            | {"user_id":"123", "code_type":"rfid"}, code type should be either "all" or one of supported types
+in     | cmd.usercode.clear_all         | null       |            | Clear all codes
+in     | cmd.usercode.clear             | str_map    |            | {"user_id":"123", "code_type":"rfid"}, code type should be either "all" or one of supported types
+
+#### Props
+
+Name           | Value example              | Description
+---------------|----------------------------|-------------
+sup_usercodes  | ["pin", "rfid"]            | List of supported user code types
+sup_usertypes  | ["master", "unrestricted"] | List of supported user code types
+sup_userstatus | ["enabled", "disabled"]    | List of supported user code types
+
+### Color control service
+
+The service has to be used to control color components of a lightning device.
+
+#### Service names
+
+`color_ctrl`
+
+#### Interfaces
+
+Type  | Interface            | Value type |  Description
+------|----------------------|------------|-------------------
+in    | cmd.color.set        | int_map    | value is a map of color components. val= {"red":200, "green":100, "blue":45}
+in    | cmd.color.get_report | null       | The command is a request for a map of color component values
+out   | evt.color.report     | int_map    | Map of color components, where value is component intensity.
+Descriptor properties:
+
+#### Props
+
+Name           | Value example            | Description
+---------------|--------------------------|-------------
+sup_components | ["red", "green", "blue"] | List of supported color components
+
+Supported color components: red, green, blue, warm_w, cold_w, temp, amber, cyan, purple
+
+#### Notes
+
+- temp - is color temperature in Kalvin. Value range 1000K-10000K.
+- warm_w - is warm white light source intensity.Value range 0-255.
+- cold_w - is cold white light source intensity.Value range 0-255.
+- Mix of warm white intensity and cold white intensity forms color temperature.
+
+### Scene controller service
+
+The service represents a device which can be used to control scenes. Normally it's remote controller.
+
+#### Service names
+
+`scene_ctrl`
+
+#### Interfaces
+
+Type  | Interface            | Value type | Description
+------|----------------------|------------|-------------------
+in    | cmd.scene.get_report | null       | The command is a request for current scene.
+in    | cmd.scene.set        | string     | Set scene
+out   | evt.scene.report     | string     | Event is generated whenever scene button is pressed on controller.
+
+#### Props
+
+Name           | Value example | Description
+---------------|---------------|-------------
+sup_scenes     | 1, a, movies  | List of supported scenes
+
+### Fan control service
+
+The service has to be used to control a fan operational modes, speed and receive state updates.
+
+#### Service names
+
+`fan_ctrl`
+
+#### Interfaces
+
+Type  | Interface              | Value type |  Description
+------|------------------------|------------|-------------------
+in    | cmd.mode.set           | string     | Fan mode. Supported values: auto_low, auto_high, auto_mid, low, high, mid,  humid_circulation, up_down,  left_right, quiet
+in    | cmd.mode.get_report    | null       | The command is a request for current fan mode report.
+out   | evt.mode.report        | string     | Current fan mode
+out   | evt.state.report       | string     | Report operational state. Supported values: idle, low, high, mid
+in    | cmd.state.get_report   | null       | The command is a request for current fan state report
+in    | cmd.lvl.set            | int        | Fan speed, value 0 - 100 %
+in    | cmd.lvl.get_report     | null       | The command is a request for current fan speed level.
+out   | evt.lvl.report         | null       | Current fan speed level.
+in    | cmd.modelvl.set        | int_map    | val = {"mid":90, "auto_low":10}
+in    | cmd.modelvl.get_report | string     | The command is a request for fan speed level for particular mode. If mode is set to "", the device should report levels for all modes.
+out   | evt.modelvl.report     | int_map    | val = {"mid":90, "auto_low":10}
+
+#### Props
+
+Name           | Value example      | Description
+---------------|--------------------|-------------
+sup_modes      | auto_low, auto_mid | List of supported modes
+sup_states     | idle, low, high    |
+
+### Siren service
+
+#### Service names
+
+`siren_ctrl`
+
+#### Interfaces
+
+Type  | Interface           | Value type | Description
+------|---------------------|------------|------------
+in    | cmd.mode.set        | string     | Control siren using selected tone
+out   | evt.mode.report     | string     |
+in    | cmd.mode.get_report | null       |
+
+Topic example: `pt:j1/mt:evt/rt:dev/rn:zw/ad:1/sv:siren_ctrl/ad:15_0`
+
+#### Props
+
+Name           | Value example       | Description
 ---------------|---------------------|-------------
-sup_components | ["is_secured","door_is_closed","bolt_is_locked","latch_is_closed"]       | List of supported lock component comoponents 
+sup_modes      | on, off, fire, leak    | List of supported tones
 
-#### User code service 
-Service name : **user_code** . 
-  
-Description : Is used by door locks ,keypads, security panels to enter and manage pin codes and rfids.
+### Barrier control service
 
- Type  | Interface                       | Value type | Properties | Description 
--------|---------------------------------|------------|------------|------------------ 
-out    | evt.usercode.config_report      | str_map    |            | {"user_id":"123","user_status":"enabled","user_type":"master","code_type":"rfid","code":"4321"}
-in     | cmd.usercode.set                | str_map    |            | {"user_id":"123","user_status":"enabled","user_type":"master","code_type":"rfid","code":"4321"}
-in     | cmd.usercode.get_config_report  | str_map    |            | {"user_id":"123","code_type":"rfid"}  , code type should be either "all" or one of supported types 
-in     | cmd.usercode.clear_all          | null       |            | Clear all codes  
-in     | cmd.usercode.clear              | str_map    |            | {"user_id":"123","code_type":"rfid"}  , code type should be either "all" or one of supported types
+The service represent devices like garage door openers, barriers, window protection shades, etc.
 
-Descriptor properties :
+#### Service names
 
-Name           | Value example       | Description 
----------------|---------------------|-------------
-sup_usercodes  | ["pin","rfid"]      | List of supported user code types 
-sup_usertypes  | ["master","unrestricted"]   | List of supported user code types 
-sup_userstatus | ["enabled","disabled"]      | List of supported user code types 
+`barrier_ctrl`
 
-#### Color control service   
-Service name : **color_ctrl** 
+#### Interfaces
 
-Description : The service has to be used to controll color components of a lightning device . 
+Type  | Interface                | Value type | Description
+------|--------------------------|------------|------------
+in    | cmd.tstate.set           | string     | Setting target state
+in    | cmd.op.stop              | null       | Emergency stop of any operation.
+out   | evt.state.report         | string     | Current state
+in    | cmd.state.get_report     | null       | Get current state
+in    | cmd.notiftype.set        | bool_map   | Configuration of notification type device is is using while opening/closing door.
+in    | cmd.notiftype.get_report | null       |
+out   | evt.notiftype.report     | bool_map   |
 
-Type  | Interface                | Value type |  Description 
-------|--------------------------|------------|-------------------
-in    | cmd.color.set            | int_map    | value is a map of color components . val= {"red":200,"green":100,"blue":45}
-in    | cmd.color.get_report     | null       | The command is a request for a map of color component values 
-out   | evt.color.report         | int_map    | Map of color components , where value is component intensity.
-Descriptor properties :
+Topic example: `pt:j1/mt:evt/rt:dev/rn:zw/ad:1/sv:berier_ctrl/ad:15_0`
 
-Name           | Value example       | Description 
----------------|---------------------|-------------
-sup_components | ["red","green","blue"]       | List of supported color comoponents 
+#### Props
 
-Supported color components : red,green,blue,warm_w,cold_w,temp,amber,cyan,purple
+Name           | Value example         | Description
+---------------|-----------------------|-------------
+sup_states     | open, closed, closing |  supported states
+sup_tstates    | open, close           |  supported target states
+sup_notiftypes | audio, visual         | supported notifications types, like siren, flashlight
 
-Notes :
-> temp - is color temperature in Kalvin. Value range 1000K-10000K .
-> warm_w - is warm white light source intensity.Value range 0-255 .
-> cold_w - is cold white light source intensity.Value range 0-255 .  
-> Mix of warm white intensity and cold white intensity forms color temperature . 
+### Complex alarm system service
 
+The service represents alarm system or sub-system with internal logic. It can be either an app or complex alarm device.
 
-#### Scene controller service
-Service name : **scene_ctrl** . 
-  
-Description : The service represents a device which can be used to controll scenes . Normally it's remote controller . 
+#### Service names
 
-Type  | Interface                | Value type |  Description 
-------|--------------------------|------------|-------------------
-in    | cmd.scene.get_report     | null       | The command is a request for current scene .  
-in    | cmd.scene.set            | string     | Set scene 
-out   | evt.scene.report         | string     | Event is generated whenever scene button is pressed on controller.
+`complex_alarm_system`
 
-Descriptor properties :
+#### Interfaces
 
-Name           | Value example       | Description 
----------------|---------------------|-------------
-sup_scenes     | 1 , a , movies      | List of supported scenes  
+Type  | Interface         | Value type | Description
+------|-------------------|----------- |------------
+in    | cmd.alarm.silence | string     | Silence sirens without ceasing alarm situation.
 
+### Gateway service
 
-#### Fan control service
-Service name : **fan_ctrl** 
+The service represents gateway, hub or host computer. Adapter topic should be used to communicate with gateway service, *pt:j1/mt:evt/rt:ad/rn:gateway/ad:1* and *pt:j1/mt:evt/rt:ad/rn:gateway/ad:1*.
 
-Description : The service has to be used to control a fan operational modes , speed and receive state opdates. 
+#### Service names
 
-Type  | Interface                | Value type |  Description 
-------|--------------------------|------------|-------------------
-in    | cmd.mode.set             | string     | Fan mode . Supported values : auto_low,auto_high,auto_mid,low,high,mid ,  humid_circulation ,up_down,  left_right ,quiet
-in    | cmd.mode.get_report      | null       | The command is a request for current fan mode report.
-out   | evt.mode.report          | string     | Current fan mode 
-out   | evt.state.report         | string     | Report operational state. Supported values : idle,low,high,mid
-in    | cmd.state.get_report     | null       | The command is a request for current fan state report  
-in    | cmd.lvl.set              | int        | Fan speed , value 0 - 100 %   
-in    | cmd.lvl.get_report       | null       | The command is a request for current fan speed level.
-out   | evt.lvl.report           | null       | Current fan speed level.
-in    | cmd.modelvl.set          | int_map    | val = {"mid":90,"auto_low":10} 
-in    | cmd.modelvl.get_report   | string     | The command is a request for fan speed level for particular mode. If mode is set to "" , the device should report levels for all modes.
-out   | evt.modelvl.report       | int_map    | val = {"mid":90,"auto_low":10} 
+`gateway`
 
+#### Interface
 
-Descriptor properties :
-
-Name           | Value example       | Description 
----------------|---------------------|-------------
-sup_modes      | auto_low,auto_mid   | List of supported modes 
-sup_states     | idle,low,high       | 
-
-
-#### Siren service
-Service name : **siren_ctrl**
-
-Description : Controlling sirens
-
-Type  | Interface                | Value type     | Description 
-------|--------------------------|----------------|------------
-in    | cmd.mode.set             | string         | Controll siren using selected tone 
-out   | evt.mode.report          | string         |
-in    | cmd.mode.get_report      | null           |
-
-Topic example : `pt:j1/mt:evt/rt:dev/rn:zw/ad:1/sv:siren_ctrl/ad:15_0`
-
-Descriptor properties : 
-
-Name           | Value example       | Description 
----------------|---------------------|-------------
-sup_modes      | on,off,fire,leak    | List of supported tones 
-
-#### Barrier control service 
-Service name : **barrier_ctrl**
-
-Description : The service represent devices like garage door openers , bariers , window protection shades , etc .
-
-Type  | Interface                 | Value type     | Description 
-------|---------------------------|----------------|------------
-in    | cmd.tstate.set            | string         | Setting target state
-in    | cmd.op.stop               | null           | Emergency stop of any operation.   
-out   | evt.state.report          | string         | Current state 
-in    | cmd.state.get_report      | null           | Get current state 
-in    | cmd.notiftype.set         | bool_map       | Configuration of notification type device is is using while opening/closing door. 
-in    | cmd.notiftype.get_report  | null           | 
-out   | evt.notiftype.report      | bool_map       |     
-
-Topic example : `pt:j1/mt:evt/rt:dev/rn:zw/ad:1/sv:berier_ctrl/ad:15_0`
-
-Descriptor properties :
-
-Name           | Value example       | Description 
----------------|---------------------|-------------
-sup_states     | open,closed,closing |  supported states 
-sup_tstates    | open,close          |  supported target states   
-sup_notiftypes | audio,visual        | supported notifications types , like siren , flashlight  
-
-
-#### Complex alarm system service 
-Service name : **complex_alarm_system**
-
-Description : The service represents alarm system or sub-system with internal logic . It can be either an app or complex alarm device.
-
-Type  | Interface                 | Value type     | Description 
-------|---------------------------|----------------|------------
-in    | cmd.alarm.silence         | string         | Silence sirens without ceasing alarm situation . 
-
-
-#### Gateway service 
-Service name : **gateway**
-
-Description : The service represents gateway , hub or host computer. Adapter topic should be used to communicate with gateway service , *pt:j1/mt:evt/rt:ad/rn:gateway/ad:1* and *pt:j1/mt:evt/rt:ad/rn:gateway/ad:1*
-
-Type  | Interface                 | Value type     | Description 
-------|---------------------------|----------------|------------
-in    | cmd.gateway.reboot        | null           | Gateways reboot
-in    | cmd.gateway.shutdown      | null           | Gateways shutdown
-in    | cmd.gateway.factory_reset | null           | Instructs gateway to perform factory reset 
-out   | evt.gateway.factory_reset | null           | Factory reset event .  
+Type  | Interface                 | Value type | Description
+------|---------------------------|------------|------------
+in    | cmd.gateway.reboot        | null       | Gateways reboot
+in    | cmd.gateway.shutdown      | null       | Gateways shutdown
+in    | cmd.gateway.factory_reset | null       | Instructs gateway to perform factory reset
+out   | evt.gateway.factory_reset | null       | Factory reset event.

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Type | Interface            | Value type | Description
 out  | evt.alarm.report     | str_map    | val = {"event": "tamper_removed_cover", "status": "activ"}
 in   | cmd.alarm.get_report | ?          |
 
-Supported statuses: activ, deactiv
+Supported statuses: activ, deactiv. IMPORTANT: These are shorthands for "activated" and "deactivated", not typos.
 
 Example message: [evt.sensor.report](json-v1/messages/examples/evt.alarm.report.json)
 

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ Service name        | Event                                   | Description
 `alarm_system`      | hw_failure, sw_failure, hw_failure_with_code, sw_failure_with_code |
 `alarm_emergency`   | police, fire, medical                   |
 `alarm_time`        | wakeup, timer_ended, time_remaining     |
-`alarm_appliance`   | program_started, program_inprogress, program_completed, replace_filter, set_temp_error, supplying_water, water_supply_err, boiling, boiling_err, washing, washing_err, rinsing, rinsing_err, draining, draining_err, spinnning, spinning_err, drying, drying_err, fan_err, compressor_err |
+`alarm_appliance`   | program_started, program_inprogress, program_completed, replace_filter, set_temp_error, supplying_water, water_supply_err, boiling, boiling_err, washing, washing_err, rinsing, rinsing_err, draining, draining_err, spinning, spinning_err, drying, drying_err, fan_err, compressor_err |
 `alarm_health`      | leaving_bed, sitting_on_bed, lying_on_bed, alarm_health, posture_change, sitting_on_bed_edge, alarm_health, volatile_organic_compound |
 `alarm_siren`       | inactive, siren_active                  |
 `alarm_water_valve` | valve_op, master_valve_op, alarm_water_valve, valve_short_circuit, current_alarm, alarm_water_valve, master_valve_current_alarm |

--- a/README.md
+++ b/README.md
@@ -53,14 +53,6 @@ Breaking down the example `pt:j1/mt:evt/rt:dev/rn:zw/ad:1/sv:out_bin_switch/ad:1
 
 Lastly, not that each interface within a service share the same address and that a service can never have more than one interface of the same type.
 
-Abstract diagram:
-
-![Fimp Service overview](static/fimp-service.png)
-
-Device example:
-
-![Fimp Service overview](static/fimp-thing-example.png)
-
 Message format:
 
 [FIMP message format](message-format.md)
@@ -119,7 +111,7 @@ in   | cmd.config.get_supp_list    | null       | Requests service to respond wi
 in   | cmd.config.set              | str_map    | Sets configuration. Value is a key-value pairs.
 in   | cmd.config.supp_list_report | str_map    | List of supported configurations. Key - config name, value - short description.
 out  | evt.config.report           | str_map    | Reports configurations in form of key-value pairs.
--|-|-|-
+-|||
 in   | cmd.group.add_members       | object     | Adds members to the group. Object has the same format as members_report
 in   | cmd.group.delete_members    | object     | Object has the same format as report.
 in   | cmd.group.get_members       | string     | Value is a group name.
@@ -165,7 +157,7 @@ Type | Interface          | Value type | Properties              | Description
 -----|--------------------|------------|-------------------------|------------
 in   | cmd.binary.set     | bool       |                         | true is mapped to 255, false to 0
 out  | evt.binary.report  | bool       |                         |
--|-|-|-
+-|||
 in   | cmd.lvl.get_report | null       |                         |
 in   | cmd.lvl.set        | int        | `duration`              |
 in   | cmd.lvl.start      | string     | `start_lvl`, `duration` |
@@ -354,7 +346,7 @@ Type | Interface          | Value type | Properties | Description
 -----|--------------------|------------|----------- |------------------
 in   | cmd.lvl.get_report | null       |            | Get battery level over level report.
 out  | evt.lvl.report     | int        | state      |
--|-|-|-
+-|||
 out  | evt.alarm.report   | str_map    |            | val = {"event": "low_battery", "status": "activ"}
 
 #### Interface props
@@ -376,11 +368,11 @@ Type | Interface               | Value type | Description
 in   | cmd.mode.get_report     | null       |
 in   | cmd.mode.set            | string     |  Set thermostat mode:
 out  | evt.mode.report         | string     |
--|-|-|-
+-|||
 in   | cmd.setpoint.get_report | string     | value is a set-point type
 in   | cmd.setpoint.set        | str_map    | val = {"type":"heat", "temp":"21.5", "unit":"C"}
 out  | evt.setpoint.report     | str_map    | val = {"type":"heat", "temp":"21.5", "unit":"C"}
--|-|-|-
+-|||
 in   | cmd.state.get_report    | null       |
 out  | evt.state.report        | string     |  Reports operational state.
 
@@ -519,15 +511,15 @@ Type | Interface              | Value type |  Description
 in   | cmd.lvl.get_report     | null       | The command is a request for current fan speed level.
 in   | cmd.lvl.set            | int        | Fan speed, value 0 - 100 %
 out  | evt.lvl.report         | null       | Current fan speed level.
--|-|-|-
+-|||
 in   | cmd.mode.get_report    | null       | The command is a request for current fan mode report.
 in   | cmd.mode.set           | string     | Fan mode. Supported values: auto_low, auto_high, auto_mid, low, high, mid,  humid_circulation, up_down,  left_right, quiet
 out  | evt.mode.report        | string     | Current fan mode
--|-|-|-
+-|||
 in   | cmd.modelvl.get_report | string     | The command is a request for fan speed level for particular mode. If mode is set to "", the device should report levels for all modes.
 in   | cmd.modelvl.set        | int_map    | val = {"mid":90, "auto_low":10}
 out  | evt.modelvl.report     | int_map    | val = {"mid":90, "auto_low":10}
--|-|-|-
+-|||
 in   | cmd.state.get_report   | null       | The command is a request for current fan state report
 out  | evt.state.report       | string     | Report operational state. Supported values: idle, low, high, mid
 
@@ -575,12 +567,12 @@ Type | Interface                | Value type | Description
 in   | cmd.notiftype.get_report | null       |
 in   | cmd.notiftype.set        | bool_map   | Configuration of notification type device is is using while opening/closing door.
 out  | evt.notiftype.report     | bool_map   |
--|-|-|-
+-|||
 in   | cmd.op.stop              | null       | Emergency stop of any operation.
--|-|-|-
+-|||
 in   | cmd.state.get_report     | null       | Get current state
 out  | evt.state.report         | string     | Current state
--|-|-|-
+-|||
 in   | cmd.tstate.set           | string     | Setting target state
 
 #### Service props

--- a/README.md
+++ b/README.md
@@ -1,6 +1,30 @@
 # Futurehome IoT Messaging Protocol - FIMP
 
-## Service overview.
+* [Service overview](#service-overview)
+* [Component discovery mechanism](#component-discovery-mechanism)
+* [Adding / removing things to FH system](#adding--removing-things-to-fh-system)
+* [Services](#services)
+   * [Basic service](#basic-service)
+   * [System related device service](#system-related-device-service)
+   * [Output binary switch service](#output-binary-switch-service)
+   * [Output level switch service](#output-level-switch-service)
+   * [Meter services](#meter-services)
+   * [Numeric sensor services](#numeric-sensor-services)
+   * [Binary sensor services](#binary-sensor-services)
+   * [Alarm services](#alarm-services)
+   * [Battery service](#battery-service)
+   * [Thermostat service](#thermostat-service)
+   * [Door lock service](#door-lock-service)
+   * [User code service](#user-code-service)
+   * [Color control service](#color-control-service)
+   * [Scene controller service](#scene-controller-service)
+   * [Fan control service](#fan-control-service)
+   * [Siren service](#siren-service)
+   * [Barrier control service](#barrier-control-service)
+   * [Complex alarm system service](#complex-alarm-system-service)
+   * [Gateway service](#gateway-service)
+
+## Service overview
 
 In FIMP, the functionality of everything that's considered a device is represented by services. These say something about the capabilities of the device, e.g. the service `out_bin_sw` indicates that some part of the device can be turned on / off. Similarly `out_lvl_sw` indicates that some part of the device accepts a value between a given min and max. Note that the services are not specific as to what part of the device they represent. An `out_bin_sw` might turn on / off part of the device, or the device itself.
 
@@ -41,13 +65,13 @@ Message format:
 
 [FIMP message format](message-format.md)
 
-## Component discovery mechanism.
+## Component discovery mechanism
 
 The mechanism allows dynamically discover different system component like adapters and application.
 
 [Component discovery flow and messages](component-discovery.md)
 
-## Adding / removing things to FH system.
+## Adding / removing things to FH system
 
 Things can be added to FH ecosystem in 2 ways:
 

--- a/README.md
+++ b/README.md
@@ -178,9 +178,9 @@ Name       | Value example | Description
 
 #### Service props
 
-Name      | Value example          | Description
-----------|------------------------|-------------
-sup_units | ["W", "kWh", "A", "V"] | list of supported units.
+Name        | Value example          | Description
+------------|------------------------|-------------
+`sup_units` | ["W", "kWh", "A", "V"] | list of supported units.
 
 ***
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ in   | cmd.config.get_supp_list    | null       | Requests service to respond wi
 in   | cmd.config.set              | str_map    | Sets configuration. Value is a key-value pairs.
 in   | cmd.config.supp_list_report | str_map    | List of supported configurations. Key - config name, value - short description.
 out  | evt.config.report           | str_map    | Reports configurations in form of key-value pairs.
------|---------------------------- |------------|------------
+|||
 in   | cmd.group.add_members       | object     | Adds members to the group. Object has the same format as members_report
 in   | cmd.group.delete_members    | object     | Object has the same format as report.
 in   | cmd.group.get_members       | string     | Value is a group name.
@@ -120,7 +120,7 @@ Type | Interface          | Value type | Properties              | Description
 -----|--------------------|------------|-------------------------|------------
 in   | cmd.binary.set     | bool       |                         | true is mapped to 255, false to 0
 out  | evt.binary.report  | bool       |                         |
------|--------------------|------------|-------------------------|------------
+|||
 in   | cmd.lvl.get_report | null       |                         |
 in   | cmd.lvl.set        | int        | `duration`              |
 in   | cmd.lvl.start      | string     | `start_lvl`, `duration` |
@@ -313,7 +313,7 @@ Type | Interface          | Value type | Properties | Description
 -----|--------------------|------------|----------- |------------------
 in   | cmd.lvl.get_report | null       |            | Get battery level over level report.
 out  | evt.lvl.report     | int        | state      |
------|--------------------|------------|----------- |------------------
+|||
 out  | evt.alarm.report   | str_map    |            | val = {"event": "low_battery", "status": "activ"}
 
 #### Interface props
@@ -335,11 +335,11 @@ Type | Interface               | Value type | Description
 in   | cmd.mode.get_report     | null       |
 in   | cmd.mode.set            | string     |  Set thermostat mode:
 out  | evt.mode.report         | string     |
------|-------------------------|------------|------------------
+|||
 in   | cmd.setpoint.get_report | string     | value is a set-point type
 in   | cmd.setpoint.set        | str_map    | val = {"type":"heat", "temp":"21.5", "unit":"C"}
 out  | evt.setpoint.report     | str_map    | val = {"type":"heat", "temp":"21.5", "unit":"C"}
------|-------------------------|------------|------------------
+|||
 in   | cmd.state.get_report    | null       |
 out  | evt.state.report        | string     |  Reports operational state.
 
@@ -478,15 +478,15 @@ Type | Interface              | Value type |  Description
 in   | cmd.lvl.get_report     | null       | The command is a request for current fan speed level.
 in   | cmd.lvl.set            | int        | Fan speed, value 0 - 100 %
 out  | evt.lvl.report         | null       | Current fan speed level.
------|------------------------|------------|-------------------
+|||
 in   | cmd.mode.get_report    | null       | The command is a request for current fan mode report.
 in   | cmd.mode.set           | string     | Fan mode. Supported values: auto_low, auto_high, auto_mid, low, high, mid,  humid_circulation, up_down,  left_right, quiet
 out  | evt.mode.report        | string     | Current fan mode
------|------------------------|------------|-------------------
+|||
 in   | cmd.modelvl.get_report | string     | The command is a request for fan speed level for particular mode. If mode is set to "", the device should report levels for all modes.
 in   | cmd.modelvl.set        | int_map    | val = {"mid":90, "auto_low":10}
 out  | evt.modelvl.report     | int_map    | val = {"mid":90, "auto_low":10}
------|------------------------|------------|-------------------
+|||
 in   | cmd.state.get_report   | null       | The command is a request for current fan state report
 out  | evt.state.report       | string     | Report operational state. Supported values: idle, low, high, mid
 
@@ -534,12 +534,12 @@ Type | Interface                | Value type | Description
 in   | cmd.notiftype.get_report | null       |
 in   | cmd.notiftype.set        | bool_map   | Configuration of notification type device is is using while opening/closing door.
 out  | evt.notiftype.report     | bool_map   |
------|--------------------------|------------|------------
+|||
 in   | cmd.op.stop              | null       | Emergency stop of any operation.
------|--------------------------|------------|------------
+|||
 in   | cmd.state.get_report     | null       | Get current state
 out  | evt.state.report         | string     | Current state
------|--------------------------|------------|------------
+|||
 in   | cmd.tstate.set           | string     | Setting target state
 
 Topic example: `pt:j1/mt:evt/rt:dev/rn:zw/ad:1/sv:berier_ctrl/ad:15_0`

--- a/README.md
+++ b/README.md
@@ -2,7 +2,32 @@
 
 ## Service overview.
 
-In FIMP, every device / app-functionality is represented as service. Every service should have at least one interface and at least one attribute. A service interacts with outer world by means of messages, it can either produce messages (events), receive messages (commands) but also in some cases it may send command. Each service has its own unique address (topic), all interfaces within the service share the same address. A service can't have more than one interface of the same type.
+In FIMP, the functionality of everything that's considered a device is represented by services. These say something about the capabilities of the device, e.g. the service `out_bin_sw` indicates that some part of the device can be turned on / off. Similarly `out_lvl_sw` indicates that some part of the device accepts a value between a given min and max. Note that the services are not specific as to what part of the device they represent. An `out_bin_sw` might turn on / off part of the device, or the device itself.
+
+Each service is further represented by interfaces, where a service must have at least one interface. An interface consist of three parts separated by a period:
+ 
+ 1. The first part of the interface is the **type**. From the perspective of the receiver, it can be either `cmd` - representing an incoming message, or `evt` - representing an outgoing message.
+ 
+ 2. The second part of the interface is the *attribute* which says something about the values supported by the interface. E.g. the `binary` attribute specifies that this interface only support boolean values. A service can have multiple interfaces with different attributes.
+ 
+ 3. The third part of the interface represents the **action** to perform in the case of a `cmd` interface, or the data in the case of `evt`. Typically this takes the form of getters ans setters. 
+
+Bringing it all together: the interface `cmd.binary.set` allows you to send a **command** to the **binary attribute** saying you want to **set** (change) it. Similarly, `evt.binary.report` says that there was an **event** (message received) on the **binary attribute** where a **report** was received.
+
+Additionally, each service it will have its own unique address (topic) over which it can send / receive messages, e.g. `pt:j1/mt:evt/rt:dev/rn:zw/ad:1/sv:basic/ad:15_0`. The address can be broken down into the following components:
+
+Type | Sample values                  | Description
+-----|--------------------------------|------------
+pt   | j1                             | parser type, typically j1, representing JSON v1.
+mt   | evt, cmd                       | message type
+rt   | ad, app, dev                   | resource type, ad = adapter, dev = device.
+rn   | zw, vinculum, zigbee, kind-owl | resource name, the actual name of the rt
+sv   | out_bin_sw, out_lvl_sw, etc.   | service name
+ad   |                                | address, the address of the preceding type.
+
+Breaking down the example `pt:j1/mt:evt/rt:dev/rn:zw/ad:1/sv:out_bin_switch/ad:11_0`, this is the address specifying JSON v1 formatted events sent to a device using zwave with address 1, and the service `out_bin_sw` with address of 11_0. Note here that zwave actually has an address. This is normally set to 1, but in the case of the gateway having multiple instances of zwave, it can be another address.
+
+Lastly, not that each interface within a service share the same address and that a service can never have more than one interface of the same type.
 
 Abstract diagram:
 

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ Each service is further represented by interfaces, where a service must have at 
  
  1. The first part of the interface is the **type**. From the perspective of the receiver, it can be either `cmd` - representing an incoming message, or `evt` - representing an outgoing message.
  
- 2. The second part of the interface is the *attribute* which says something about the values supported by the interface. E.g. the `binary` attribute specifies that this interface only support boolean values. A service can have multiple interfaces with different attributes.
+ 2. The second part of the interface is the **attribute** which says something about the values supported by the interface. E.g. the `binary` attribute specifies that this interface only support boolean values. A service can have multiple interfaces with different attributes.
  
  3. The third part of the interface represents the **action** to perform in the case of a `cmd` interface, or the data in the case of `evt`. Typically this takes the form of getters ans setters. 
 
 Bringing it all together: the interface `cmd.binary.set` allows you to send a **command** to the **binary attribute** saying you want to **set** (change) it. Similarly, `evt.binary.report` says that there was an **event** (message received) on the **binary attribute** where a **report** was received.
 
-Additionally, each service it will have its own unique address (topic) over which it can send / receive messages, e.g. `pt:j1/mt:evt/rt:dev/rn:zw/ad:1/sv:basic/ad:15_0`. The address can be broken down into the following components:
+Additionally, each service it will have its own unique address (topic) over which it can send / receive messages, e.g. `pt:j1/mt:evt/rt:dev/rn:zw/ad:1/sv:out_bin_switch/ad:11_0`. The address can be broken down into the following components:
 
 Type | Sample values                  | Description
 -----|--------------------------------|------------
@@ -23,7 +23,7 @@ mt   | evt, cmd                       | message type
 rt   | ad, app, dev                   | resource type, ad = adapter, dev = device.
 rn   | zw, vinculum, zigbee, kind-owl | resource name, the actual name of the rt
 sv   | out_bin_sw, out_lvl_sw, etc.   | service name
-ad   |                                | address, the address of the preceding type.
+ad   |                                | the address of the preceding type.
 
 Breaking down the example `pt:j1/mt:evt/rt:dev/rn:zw/ad:1/sv:out_bin_switch/ad:11_0`, this is the address specifying JSON v1 formatted events sent to a device using zwave with address 1, and the service `out_bin_sw` with address of 11_0. Note here that zwave actually has an address. This is normally set to 1, but in the case of the gateway having multiple instances of zwave, it can be another address.
 
@@ -78,8 +78,6 @@ in   | cmd.lvl.get_report | null       |
 in   | cmd.lvl.set        | int        | Sets level using numeric value
 out  | evt.lvl.report     | int        | Reports level using numeric value
 
-Topic example: `pt:j1/mt:evt/rt:dev/rn:zw/ad:1/sv:basic/ad:15_0`
-
 ***
 
 ### System related device service
@@ -127,8 +125,6 @@ in   | cmd.binary.get_report | null       |
 in   | cmd.binary.set        | bool       |
 out  | evt.binary.report     | bool       | Reports true when switch is ON and false when switch is OFF
 
-Topic example: `pt:j1/mt:cmd/rt:dev/rn:zw/ad:1/sv:out_bin_switch/ad:15_0`
-
 ***
 
 ### Output level switch service
@@ -151,8 +147,6 @@ in   | cmd.lvl.set        | int        | `duration`              |
 in   | cmd.lvl.start      | string     | `start_lvl`, `duration` |
 in   | cmd.lvl.stop       | null       |                         | Stop a level change
 out  | evt.lvl.report     | int        |                         |
-
-Topic example: `pt:j1/mt:cmd/rt:dev/rn:zw/ad:1/sv:out_lvl_switch/ad:15_0`
 
 #### Interface props
 
@@ -190,8 +184,6 @@ Type | Interface            | Value type | Properties              | Description
 in   | cmd.meter.get_report | string     |                         | Value - is a unit. May not be supported by all meters.
 in   | cmd.meter.reset      | null       |                         | Resets all historical readings.
 out  | evt.meter.report     | float      | unit, prv_data, delta_t |
-
-Topic example: `pt:j1/mt:evt/rt:dev/rn:zw/ad:1/sv:meter_elec/ad:15_0`
 
 #### Interface props
 
@@ -567,13 +559,11 @@ out  | evt.state.report         | string     | Current state
 -|-|-|-
 in   | cmd.tstate.set           | string     | Setting target state
 
-Topic example: `pt:j1/mt:evt/rt:dev/rn:zw/ad:1/sv:berier_ctrl/ad:15_0`
-
 #### Service props
 
 Name             | Value example         | Description
 -----------------|-----------------------|-------------
-`sup_notiftypes` | audio, visual         | supported notifications types, like siren, flashlight
+`sup_notiftypes` | audio, visual         | supported notification-types, like siren, flashlight
 `sup_states`     | open, closed, closing | supported states
 `sup_tstates`    | open, close           | supported target states
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Message format:
 
 The mechanism allows dynamically discover different system component like adapters and application.
 
-[Component discovery flow and messages ](component-discovery.md)
+[Component discovery flow and messages](component-discovery.md)
 
 ## Adding / removing things to FH system.
 
@@ -65,17 +65,17 @@ Topic example: `pt:j1/mt:evt/rt:dev/rn:zw/ad:1/sv:basic/ad:15_0`
 
 #### Interfaces
 
-Type  | Interface                   | Value type | Description
-------|---------------------------- |------------|------------
-out   | evt.config.report           | str_map    | Reports configurations in form of key-value pairs.
-in    | cmd.config.set              | str_map    | Sets configuration. Value is a key-value pairs.
-in    | cmd.config.get_report       | str_array  | Requests service to respond with config report. If array is empty - report all parameters.
-in    | cmd.config.get_supp_list    | null       | Requests service to respond with a list of supported configurations.
-in    | cmd.config.supp_list_report | str_map    | List of supported configurations. Key - config name, value - short description.
-out   | evt.group.members_report    | object     | Object structure {"group":"group1", "members":["node1", "node2"]}
-in    | cmd.group.add_members       | object     | Adds members to the group. Object has the same format as members_report
-in    | cmd.group.delete_members    | object     | Object has the same format as report.
-in    | cmd.group.get_members       | string     | Value is a group name.
+Type | Interface                   | Value type | Description
+-----|---------------------------- |------------|------------
+out  | evt.config.report           | str_map    | Reports configurations in form of key-value pairs.
+in   | cmd.config.set              | str_map    | Sets configuration. Value is a key-value pairs.
+in   | cmd.config.get_report       | str_array  | Requests service to respond with config report. If array is empty - report all parameters.
+in   | cmd.config.get_supp_list    | null       | Requests service to respond with a list of supported configurations.
+in   | cmd.config.supp_list_report | str_map    | List of supported configurations. Key - config name, value - short description.
+out  | evt.group.members_report    | object     | Object structure {"group":"group1", "members":["node1", "node2"]}
+in   | cmd.group.add_members       | object     | Adds members to the group. Object has the same format as members_report
+in   | cmd.group.delete_members    | object     | Object has the same format as report.
+in   | cmd.group.get_members       | string     | Value is a group name.
 
 #### Notes
 
@@ -95,11 +95,11 @@ Output binary switch service for wall-plugs, relays, simple sirens, etc.
 
 #### Interfaces
 
-Type  | Interface             | Value type | Description
-------|-----------------------|------------|------------
-out   | evt.binary.report     | bool       | Reports true when switch is ON and false when switch is OFF
-in    | cmd.binary.set        | bool       |
-in    | cmd.binary.get_report | null       |
+Type | Interface             | Value type | Description
+-----|-----------------------|------------|------------
+out  | evt.binary.report     | bool       | Reports true when switch is ON and false when switch is OFF
+in   | cmd.binary.set        | bool       |
+in   | cmd.binary.get_report | null       |
 
 Topic example: `pt:j1/mt:cmd/rt:dev/rn:zw/ad:1/sv:out_bin_switch/ad:15_0`
 
@@ -115,25 +115,25 @@ Used for dimmers and things generally controlled with sliders.
 
 #### Interfaces
 
-Type  | Interface          | Value type | Properties          | Description
-------|--------------------|------------|---------------------|------------
-out   | evt.lvl.report     | int        |                     |
-in    | cmd.lvl.set        | int        | duration            | props = {"duration":"5"}. Duration is in seconds, factory default is used is propery is not defined.
-in    | cmd.lvl.start      | string     | start_lvl, duration | Start a level change. Value defines direction can be: up, down, auto
-in    | cmd.lvl.stop       | null       |                     | Stop a level change
-in    | cmd.lvl.get_report | null       |                     |
-in    | cmd.binary.set     | bool       |                     | true is mapped t 255, false to 0
-out   | evt.binary.report  | bool       |                     |
+Type | Interface          | Value type | Properties          | Description
+-----|--------------------|------------|---------------------|------------
+out  | evt.lvl.report     | int        |                     |
+in   | cmd.lvl.set        | int        | duration            | props = {"duration":"5"}. Duration is in seconds, factory default is used is propery is not defined.
+in   | cmd.lvl.start      | string     | start_lvl, duration | Start a level change. Value defines direction can be: up, down, auto
+in   | cmd.lvl.stop       | null       |                     | Stop a level change
+in   | cmd.lvl.get_report | null       |                     |
+in   | cmd.binary.set     | bool       |                     | true is mapped t 255, false to 0
+out  | evt.binary.report  | bool       |                     |
 
 Topic example: `pt:j1/mt:cmd/rt:dev/rn:zw/ad:1/sv:out_lvl_switch/ad:15_0`
 
 #### Props
 
-Name      | Value example    | Description
-----------|------------------|-------------
-min_lvl   | 0                | minimum value
-max_lvl   | 99               | maximum value
-sw_type   | on_off, up_down  | type of level switch
+Name    | Value example   | Description
+--------|-----------------|-------------
+min_lvl | 0               | minimum value
+max_lvl | 99              | maximum value
+sw_type | on_off, up_down | type of level switch
 
 ***
 
@@ -151,18 +151,18 @@ Service name  | Units                                     | Description
 
 #### Interfaces
 
-Type  | Interface                | Value type | Properties                | Description
-------|--------------------------|------------|---------------------------|-------------
-out   | evt.meter.report         | float      | unit, prv_data, delta_t | prv_data - previous meter reading, delta_t - time delta
-in    | cmd.meter.reset          | null       |                           | Resets all historical readings.
-in    | cmd.meter.get_report     | string     |                           | Value - is a unit. May not be supported by all meter.
+Type | Interface            | Value type | Properties              | Description
+-----|----------------------|------------|-------------------------|-------------
+out  | evt.meter.report     | float      | unit, prv_data, delta_t | prv_data - previous meter reading, delta_t - time delta
+in   | cmd.meter.reset      | null       |                         | Resets all historical readings.
+in   | cmd.meter.get_report | string     |                         | Value - is a unit. May not be supported by all meter.
 
 Topic example: `pt:j1/mt:evt/rt:dev/rn:zw/ad:1/sv:meter_elec/ad:15_0`
 
 #### Props
 
-Name      | Value example       | Description
-----------|---------------------|-------------
+Name      | Value example          | Description
+----------|------------------------|-------------
 sup_units | ["W", "kWh", "A", "V"] | list of supported units.
 
 ***
@@ -210,18 +210,18 @@ Service name         | Units                    | Description
 
 #### Interfaces
 
-Type   | Interface                | Value type | Properties                | Description
--------|--------------------------|------------|---------------------------|-------------
-out    | evt.sensor.report        | float      | unit                      |
-in     | cmd.sensor.get_report    | string     |                           | Value is desired unit. Use empty value to get report in default unit.
+Type | Interface             | Value type | Properties | Description
+-----|-----------------------|------------|------------|-------------
+out  | evt.sensor.report     | float      | unit       |
+in   | cmd.sensor.get_report | string     |            | Value is desired unit. Use empty value to get report in default unit.
 
 Example message: [evt.sensor.report](json-v1/messages/examples/evt.sensor.report)
 
 #### Props
 
-Name      | Value example    | Description
-----------|------------------|-------------
-sup_units | ["C", "F"]       | list of supported units.
+Name      | Value example | Description
+----------|---------------|-------------
+sup_units | ["C", "F"]    | list of supported units.
 
 ***
 
@@ -235,10 +235,10 @@ Binary contact sensor, normally magnetic contact.
 
 #### Interfaces
 
-Type   | Interface           | Value type | Description
--------|---------------------|------------|--------------------
-out    | evt.open.report     | bool       | true - contact is open (window/door is open), false - contact is closed.
-in     | cmd.open.get_report | null       |
+Type | Interface           | Value type | Description
+-----|---------------------|------------|--------------------
+out  | evt.open.report     | bool       | true - contact is open (window/door is open), false - contact is closed.
+in   | cmd.open.get_report | null       |
 
 ***
 
@@ -248,14 +248,14 @@ Motion sensor or some other way of presence detection.
 
 #### Service names
 
-> Service name: `sensor_presence`
+`sensor_presence`
 
 #### Interfaces
 
-Type   | Interface                | Value type | Description
--------|--------------------------|------------|--------------------
-out    | evt.presence.report      | bool       | true - presence detected.
-in     | cmd.presence.get_report  | null       |
+Type | Interface               | Value type | Description
+-----|-------------------------|------------|--------------------
+out  | evt.presence.report     | bool       | true - presence detected.
+in   | cmd.presence.get_report | null       |
 
 ***
 
@@ -263,30 +263,30 @@ in     | cmd.presence.get_report  | null       |
 
 #### Service names
 
-Service name         | Event                                   | Description
----------------------|-----------------------------------------|------------
-`alarm_fire`         | smoke, smoke_test                       |
-`alarm_heat`         | overheat, temp_rise, underheat          |
-`alarm_gas`          | CO, CO2, combust_gas_detected, toxic_gas_detected, test, replace |
-`alarm_water`        | leak, level_drop, replace_filter        |
-`alarm_lock`         | manual_lock, rf_lock, keypad_lock, manual_not_locked, rf_not_locked, auto_locked, jammed | TODO: move to doorlock service
-`alarm_burglar`      | intrusion, tamper_removed_cover, alarm_burglar, tamper_invalid_code, glass_breakage |
-`alarm_power`        | on, ac_on, ac_off, surge, voltage_drop, over_current, over_voltage, replace_soon, replace_now, charging, charged, charge_soon, charge_now | TODO: move to power_supply service
-`alarm_system`       | hw_failure, sw_failure, hw_failure_with_code, sw_failure_with_code |
-`alarm_emergency`    | police, fire, medical                   |
-`alarm_time`         | wakeup, timer_ended, time_remaining     |
-`alarm_applience`    | program_started, program_inprogress, program_completed, replace_filter, set_temp_error, supplying_water, water_supply_err, boiling, boiling_err, washing, washing_err, rinsing, rinsing_err, draining, draining_err, spinnning, spinning_err, drying, drying_err, fan_err, compressor_err |
-`alarm_health`       | leaving_bed, sitting_on_bed, lying_on_bed, alarm_health, posture_change, sitting_on_bed_edge, alarm_health, volatile_organic_compound |
-`alarm_siren`        | inactive, siren_active                  |
-`alarm_water_valve`  | valve_op, master_valve_op, alarm_water_valve, valve_short_circuit, current_alarm, alarm_water_valve, master_valve_current_alarm |
-`alarm_weather`      | inactive, moisture                      |
+Service name        | Event                                   | Description
+--------------------|-----------------------------------------|------------
+`alarm_fire`        | smoke, smoke_test                       |
+`alarm_heat`        | overheat, temp_rise, underheat          |
+`alarm_gas`         | CO, CO2, combust_gas_detected, toxic_gas_detected, test, replace |
+`alarm_water`       | leak, level_drop, replace_filter        |
+`alarm_lock`        | manual_lock, rf_lock, keypad_lock, manual_not_locked, rf_not_locked, auto_locked, jammed | TODO: move to doorlock service
+`alarm_burglar`     | intrusion, tamper_removed_cover, alarm_burglar, tamper_invalid_code, glass_breakage |
+`alarm_power`       | on, ac_on, ac_off, surge, voltage_drop, over_current, over_voltage, replace_soon, replace_now, charging, charged, charge_soon, charge_now | TODO: move to power_supply service
+`alarm_system`      | hw_failure, sw_failure, hw_failure_with_code, sw_failure_with_code |
+`alarm_emergency`   | police, fire, medical                   |
+`alarm_time`        | wakeup, timer_ended, time_remaining     |
+`alarm_applience`   | program_started, program_inprogress, program_completed, replace_filter, set_temp_error, supplying_water, water_supply_err, boiling, boiling_err, washing, washing_err, rinsing, rinsing_err, draining, draining_err, spinnning, spinning_err, drying, drying_err, fan_err, compressor_err |
+`alarm_health`      | leaving_bed, sitting_on_bed, lying_on_bed, alarm_health, posture_change, sitting_on_bed_edge, alarm_health, volatile_organic_compound |
+`alarm_siren`       | inactive, siren_active                  |
+`alarm_water_valve` | valve_op, master_valve_op, alarm_water_valve, valve_short_circuit, current_alarm, alarm_water_valve, master_valve_current_alarm |
+`alarm_weather`     | inactive, moisture                      |
 
 #### Interfaces
 
-Type   | Interface                | Value type | Description
--------|--------------------------|------------|--------------------
-out    | evt.alarm.report         | str_map    | val = {"event": "tamper_removed_cover", "status": "activ"}
-in     | cmd.alarm.get_report     | ?          |
+Type | Interface            | Value type | Description
+-----|----------------------|------------|--------------------
+out  | evt.alarm.report     | str_map    | val = {"event": "tamper_removed_cover", "status": "activ"}
+in   | cmd.alarm.get_report | ?          |
 
 Supported statuses: activ, deactiv
 
@@ -308,11 +308,11 @@ sup_events | ["smoke", "smoke_test"] | supported events.
 
 #### Interfaces
 
- Type  | Interface          | Value type | Properties | Description
--------|--------------------|------------|----------- |------------------
-out    | evt.lvl.report     | int        | state      | available states: charging, charged, replace, emtpy
-out    | evt.alarm.report   | str_map    |            | val = {"event": "low_battery", "status": "activ"}
-in     | cmd.lvl.get_report | null       |            | Get battery level over level report.
+Type | Interface          | Value type | Properties | Description
+-----|--------------------|------------|----------- |------------------
+out  | evt.lvl.report     | int        | state      | available states: charging, charged, replace, emtpy
+out  | evt.alarm.report   | str_map    |            | val = {"event": "low_battery", "status": "activ"}
+in   | cmd.lvl.get_report | null       |            | Get battery level over level report.
 
 ### Thermostat service
 
@@ -322,16 +322,16 @@ in     | cmd.lvl.get_report | null       |            | Get battery level over l
 
 #### Interfaces
 
- Type  | Interface                  | Value type | Properties | Description
--------|----------------------------|------------|----------- |------------------
-out    | evt.setpoint.report        | str_map    |            | val = {"type":"heat", "temp":"21.5", "unit":"C"}
-in     | cmd.setpoint.set           | str_map    |            | val = {"type":"heat", "temp":"21.5", "unit":"C"}
-in     | cmd.setpoint.get_report    | string     |            | value is a set-point type
-in     | cmd.mode.set               | string     |            |  Set thermostat mode:
-in     | cmd.mode.get_report        | null       |            |
-out    | evt.mode.report            | string     |            |
-out    | evt.state.report           | string     |            |  Reports operational state.
-in     | cmd.state.get_report       | null       |            |
+Type | Interface               | Value type | Description
+-----|-------------------------|------------|------------------
+out  | evt.setpoint.report     | str_map    | val = {"type":"heat", "temp":"21.5", "unit":"C"}
+in   | cmd.setpoint.set        | str_map    | val = {"type":"heat", "temp":"21.5", "unit":"C"}
+in   | cmd.setpoint.get_report | string     | value is a set-point type
+in   | cmd.mode.set            | string     |  Set thermostat mode:
+in   | cmd.mode.get_report     | null       |
+out  | evt.mode.report         | string     |
+out  | evt.state.report        | string     |  Reports operational state.
+in   | cmd.state.get_report    | null       |
 
 #### Props
 
@@ -353,18 +353,18 @@ Set-point types: heat, cool, furnace, dry_air, moist_air, auto_changeover, energ
 
 #### Interfaces
 
- Type  | Interface                | Value type | Properties            | Description
--------|--------------------------|------------|-----------------------|------------------
-out    | evt.lock.report          | bool_map   | timeout_s, lock_type  | value = {"is_secured":true, "door_is_closed":true, "bolt_is_locked":true, "latch_is_closed":true}, lock_type properties reports how lock was locked or unlocked, it can take values: "key", "pin", "rfid"
-in     | cmd.lock.set             | bool       |                       | Use true to secure a lock and false to unsecure
-in     | cmd.lock.set_with_code   | str_map    |                       | Used to lock/unlock locks required PIN/RFID, {“op”:”lock”, ”code_type”:”pin”, ”12345” }
-in     | cmd.lock.get_report      | null       |                       |
+Type | Interface               | Value type | Properties           | Description
+-----|-------------------------|------------|----------------------|------------------
+out  | evt.lock.report         | bool_map   | timeout_s, lock_type | value = {"is_secured":true, "door_is_closed":true, "bolt_is_locked":true, "latch_is_closed":true}, lock_type properties reports how lock was locked or unlocked, it can take values: "key", "pin", "rfid"
+in   | cmd.lock.set            | bool       |                      | Use true to secure a lock and false to unsecure
+in   | cmd.lock.set_with_code  | str_map    |                      | Used to lock/unlock locks required PIN/RFID, {“op”:”lock”, ”code_type”:”pin”, ”12345” }
+in   | cmd.lock.get_report     | null       |                      |
 
 #### Props
 
-Name           | Value example       | Description
----------------|---------------------|-------------
-sup_components | ["is_secured", "door_is_closed", "bolt_is_locked", "latch_is_closed"]       | List of supported lock component comoponents
+Name           | Value example                                                         | Description
+---------------|-----------------------------------------------------------------------|-------------
+sup_components | ["is_secured", "door_is_closed", "bolt_is_locked", "latch_is_closed"] | List of supported lock component components
 
 ### User code service
 
@@ -374,13 +374,13 @@ Is used by door locks, keypads, security panels to enter and manage pin codes an
 
 `user_code`
 
-Type   | Interface                      | Value type | Properties | Description
--------|--------------------------------|------------|------------|------------------
-out    | evt.usercode.config_report     | str_map    |            | {"user_id":"123", "user_status":"enabled", "user_type":"master", "code_type":"rfid", "code":"4321"}
-in     | cmd.usercode.set               | str_map    |            | {"user_id":"123", "user_status":"enabled", "user_type":"master", "code_type":"rfid", "code":"4321"}
-in     | cmd.usercode.get_config_report | str_map    |            | {"user_id":"123", "code_type":"rfid"}, code type should be either "all" or one of supported types
-in     | cmd.usercode.clear_all         | null       |            | Clear all codes
-in     | cmd.usercode.clear             | str_map    |            | {"user_id":"123", "code_type":"rfid"}, code type should be either "all" or one of supported types
+Type | Interface                      | Value type | Description
+-----|--------------------------------|------------|------------------
+out  | evt.usercode.config_report     | str_map    | {"user_id":"123", "user_status":"enabled", "user_type":"master", "code_type":"rfid", "code":"4321"}
+in   | cmd.usercode.set               | str_map    | {"user_id":"123", "user_status":"enabled", "user_type":"master", "code_type":"rfid", "code":"4321"}
+in   | cmd.usercode.get_config_report | str_map    | {"user_id":"123", "code_type":"rfid"}, code type should be either "all" or one of supported types
+in   | cmd.usercode.clear_all         | null       | Clear all codes
+in   | cmd.usercode.clear             | str_map    | {"user_id":"123", "code_type":"rfid"}, code type should be either "all" or one of supported types
 
 #### Props
 
@@ -400,12 +400,11 @@ The service has to be used to control color components of a lightning device.
 
 #### Interfaces
 
-Type  | Interface            | Value type |  Description
-------|----------------------|------------|-------------------
-in    | cmd.color.set        | int_map    | value is a map of color components. val= {"red":200, "green":100, "blue":45}
-in    | cmd.color.get_report | null       | The command is a request for a map of color component values
-out   | evt.color.report     | int_map    | Map of color components, where value is component intensity.
-Descriptor properties:
+Type | Interface            | Value type |  Description
+-----|----------------------|------------|-------------------
+in   | cmd.color.set        | int_map    | value is a map of color components. val= {"red":200, "green":100, "blue":45}
+in   | cmd.color.get_report | null       | The command is a request for a map of color component values
+out  | evt.color.report     | int_map    | Map of color components, where value is component intensity.
 
 #### Props
 
@@ -432,17 +431,17 @@ The service represents a device which can be used to control scenes. Normally it
 
 #### Interfaces
 
-Type  | Interface            | Value type | Description
-------|----------------------|------------|-------------------
-in    | cmd.scene.get_report | null       | The command is a request for current scene.
-in    | cmd.scene.set        | string     | Set scene
-out   | evt.scene.report     | string     | Event is generated whenever scene button is pressed on controller.
+Type | Interface            | Value type | Description
+-----|----------------------|------------|-------------------
+in   | cmd.scene.get_report | null       | The command is a request for current scene.
+in   | cmd.scene.set        | string     | Set scene
+out  | evt.scene.report     | string     | Event is generated whenever scene button is pressed on controller.
 
 #### Props
 
-Name           | Value example | Description
----------------|---------------|-------------
-sup_scenes     | 1, a, movies  | List of supported scenes
+Name       | Value example | Description
+-----------|---------------|-------------
+sup_scenes | 1, a, movies  | List of supported scenes
 
 ### Fan control service
 
@@ -454,26 +453,26 @@ The service has to be used to control a fan operational modes, speed and receive
 
 #### Interfaces
 
-Type  | Interface              | Value type |  Description
-------|------------------------|------------|-------------------
-in    | cmd.mode.set           | string     | Fan mode. Supported values: auto_low, auto_high, auto_mid, low, high, mid,  humid_circulation, up_down,  left_right, quiet
-in    | cmd.mode.get_report    | null       | The command is a request for current fan mode report.
-out   | evt.mode.report        | string     | Current fan mode
-out   | evt.state.report       | string     | Report operational state. Supported values: idle, low, high, mid
-in    | cmd.state.get_report   | null       | The command is a request for current fan state report
-in    | cmd.lvl.set            | int        | Fan speed, value 0 - 100 %
-in    | cmd.lvl.get_report     | null       | The command is a request for current fan speed level.
-out   | evt.lvl.report         | null       | Current fan speed level.
-in    | cmd.modelvl.set        | int_map    | val = {"mid":90, "auto_low":10}
-in    | cmd.modelvl.get_report | string     | The command is a request for fan speed level for particular mode. If mode is set to "", the device should report levels for all modes.
-out   | evt.modelvl.report     | int_map    | val = {"mid":90, "auto_low":10}
+Type | Interface              | Value type |  Description
+-----|------------------------|------------|-------------------
+in   | cmd.mode.set           | string     | Fan mode. Supported values: auto_low, auto_high, auto_mid, low, high, mid,  humid_circulation, up_down,  left_right, quiet
+in   | cmd.mode.get_report    | null       | The command is a request for current fan mode report.
+out  | evt.mode.report        | string     | Current fan mode
+out  | evt.state.report       | string     | Report operational state. Supported values: idle, low, high, mid
+in   | cmd.state.get_report   | null       | The command is a request for current fan state report
+in   | cmd.lvl.set            | int        | Fan speed, value 0 - 100 %
+in   | cmd.lvl.get_report     | null       | The command is a request for current fan speed level.
+out  | evt.lvl.report         | null       | Current fan speed level.
+in   | cmd.modelvl.set        | int_map    | val = {"mid":90, "auto_low":10}
+in   | cmd.modelvl.get_report | string     | The command is a request for fan speed level for particular mode. If mode is set to "", the device should report levels for all modes.
+out  | evt.modelvl.report     | int_map    | val = {"mid":90, "auto_low":10}
 
 #### Props
 
-Name           | Value example      | Description
----------------|--------------------|-------------
-sup_modes      | auto_low, auto_mid | List of supported modes
-sup_states     | idle, low, high    |
+Name       | Value example      | Description
+-----------|--------------------|-------------
+sup_modes  | auto_low, auto_mid | List of supported modes
+sup_states | idle, low, high    |
 
 ### Siren service
 
@@ -483,11 +482,11 @@ sup_states     | idle, low, high    |
 
 #### Interfaces
 
-Type  | Interface           | Value type | Description
-------|---------------------|------------|------------
-in    | cmd.mode.set        | string     | Control siren using selected tone
-out   | evt.mode.report     | string     |
-in    | cmd.mode.get_report | null       |
+Type | Interface           | Value type | Description
+-----|---------------------|------------|------------
+in   | cmd.mode.set        | string     | Control siren using selected tone
+out  | evt.mode.report     | string     |
+in   | cmd.mode.get_report | null       |
 
 Topic example: `pt:j1/mt:evt/rt:dev/rn:zw/ad:1/sv:siren_ctrl/ad:15_0`
 
@@ -507,15 +506,15 @@ The service represent devices like garage door openers, barriers, window protect
 
 #### Interfaces
 
-Type  | Interface                | Value type | Description
-------|--------------------------|------------|------------
-in    | cmd.tstate.set           | string     | Setting target state
-in    | cmd.op.stop              | null       | Emergency stop of any operation.
-out   | evt.state.report         | string     | Current state
-in    | cmd.state.get_report     | null       | Get current state
-in    | cmd.notiftype.set        | bool_map   | Configuration of notification type device is is using while opening/closing door.
-in    | cmd.notiftype.get_report | null       |
-out   | evt.notiftype.report     | bool_map   |
+Type | Interface                | Value type | Description
+-----|--------------------------|------------|------------
+in   | cmd.tstate.set           | string     | Setting target state
+in   | cmd.op.stop              | null       | Emergency stop of any operation.
+out  | evt.state.report         | string     | Current state
+in   | cmd.state.get_report     | null       | Get current state
+in   | cmd.notiftype.set        | bool_map   | Configuration of notification type device is is using while opening/closing door.
+in   | cmd.notiftype.get_report | null       |
+out  | evt.notiftype.report     | bool_map   |
 
 Topic example: `pt:j1/mt:evt/rt:dev/rn:zw/ad:1/sv:berier_ctrl/ad:15_0`
 
@@ -537,9 +536,9 @@ The service represents alarm system or sub-system with internal logic. It can be
 
 #### Interfaces
 
-Type  | Interface         | Value type | Description
-------|-------------------|----------- |------------
-in    | cmd.alarm.silence | string     | Silence sirens without ceasing alarm situation.
+Type | Interface         | Value type | Description
+-----|-------------------|----------- |------------
+in   | cmd.alarm.silence | string     | Silence sirens without ceasing alarm situation.
 
 ### Gateway service
 
@@ -551,9 +550,9 @@ The service represents gateway, hub or host computer. Adapter topic should be us
 
 #### Interface
 
-Type  | Interface                 | Value type | Description
-------|---------------------------|------------|------------
-in    | cmd.gateway.reboot        | null       | Gateways reboot
-in    | cmd.gateway.shutdown      | null       | Gateways shutdown
-in    | cmd.gateway.factory_reset | null       | Instructs gateway to perform factory reset
-out   | evt.gateway.factory_reset | null       | Factory reset event.
+Type | Interface                 | Value type | Description
+-----|---------------------------|------------|------------
+in   | cmd.gateway.reboot        | null       | Gateways reboot
+in   | cmd.gateway.shutdown      | null       | Gateways shutdown
+in   | cmd.gateway.factory_reset | null       | Instructs gateway to perform factory reset
+out  | evt.gateway.factory_reset | null       | Factory reset event.

--- a/gh-md-toc
+++ b/gh-md-toc
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+
+#
+# Steps:
+#
+#  1. Download corresponding html file for some README.md:
+#       curl -s $1
+#
+#  2. Discard rows where no substring 'user-content-' (github's markup):
+#       awk '/user-content-/ { ...
+#
+#  3.1 Get last number in each row like ' ... </span></a>sitemap.js</h1'.
+#      It's a level of the current header:
+#       substr($0, length($0), 1)
+#
+#  3.2 Get level from 3.1 and insert corresponding number of spaces before '*':
+#       sprintf("%*s", substr($0, length($0), 1)*3, " ")
+#
+#  4. Find head's text and insert it inside "* [ ... ]":
+#       substr($0, match($0, /a>.*<\/h/)+2, RLENGTH-5)
+#
+#  5. Find anchor and insert it inside "(...)":
+#       substr($0, match($0, "href=\"[^\"]+?\" ")+6, RLENGTH-8)
+#
+
+gh_toc_version="0.6.1"
+
+gh_user_agent="gh-md-toc v$gh_toc_version"
+
+#
+# Download rendered into html README.md by its url.
+#
+#
+gh_toc_load() {
+    local gh_url=$1
+
+    if type curl &>/dev/null; then
+        curl --user-agent "$gh_user_agent" -s "$gh_url"
+    elif type wget &>/dev/null; then
+        wget --user-agent="$gh_user_agent" -qO- "$gh_url"
+    else
+        echo "Please, install 'curl' or 'wget' and try again."
+        exit 1
+    fi
+}
+
+#
+# Converts local md file into html by GitHub
+#
+# ➥ curl -X POST --data '{"text": "Hello world github/linguist#1 **cool**, and #1!"}' https://api.github.com/markdown
+# <p>Hello world github/linguist#1 <strong>cool</strong>, and #1!</p>'"
+gh_toc_md2html() {
+    local gh_file_md=$1
+    URL=https://api.github.com/markdown/raw
+    if [ ! -z "$GH_TOC_TOKEN" ]; then
+        TOKEN=$GH_TOC_TOKEN
+    else
+        TOKEN="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/token.txt"
+    fi
+    if [ -f "$TOKEN" ]; then
+        URL="$URL?access_token=$(cat $TOKEN)"
+    fi
+    # echo $URL 1>&2
+    OUTPUT="$(curl -s --user-agent "$gh_user_agent" \
+        --data-binary @"$gh_file_md" -H "Content-Type:text/plain" \
+        $URL)"
+
+    if [ "$?" != "0" ]; then
+        echo "XXNetworkErrorXX"
+    fi
+    if [ "$(echo "${OUTPUT}" | awk '/API rate limit exceeded/')" != "" ]; then
+        echo "XXRateLimitXX"
+    else
+        echo "${OUTPUT}"
+    fi
+}
+
+
+#
+# Is passed string url
+#
+gh_is_url() {
+    case $1 in
+        https* | http*)
+            echo "yes";;
+        *)
+            echo "no";;
+    esac
+}
+
+#
+# TOC generator
+#
+gh_toc(){
+    local gh_src=$1
+    local gh_src_copy=$1
+    local gh_ttl_docs=$2
+    local need_replace=$3
+
+    if [ "$gh_src" = "" ]; then
+        echo "Please, enter URL or local path for a README.md"
+        exit 1
+    fi
+
+
+    # Show "TOC" string only if working with one document
+    if [ "$gh_ttl_docs" = "1" ]; then
+
+        echo "Table of Contents"
+        echo "================="
+        echo ""
+        gh_src_copy=""
+
+    fi
+
+    if [ "$(gh_is_url "$gh_src")" == "yes" ]; then
+        gh_toc_load "$gh_src" | gh_toc_grab "$gh_src_copy"
+        if [ "${PIPESTATUS[0]}" != "0" ]; then
+            echo "Could not load remote document."
+            echo "Please check your url or network connectivity"
+            exit 1
+        fi
+        if [ "$need_replace" = "yes" ]; then
+            echo
+            echo "!! '$gh_src' is not a local file"
+            echo "!! Can't insert the TOC into it."
+            echo
+        fi
+    else
+        local rawhtml=$(gh_toc_md2html "$gh_src")
+        if [ "$rawhtml" == "XXNetworkErrorXX" ]; then
+             echo "Parsing local markdown file requires access to github API"
+             echo "Please make sure curl is installed and check your network connectivity"
+             exit 1
+        fi
+        if [ "$rawhtml" == "XXRateLimitXX" ]; then
+             echo "Parsing local markdown file requires access to github API"
+             echo "Error: You exceeded the hourly limit. See: https://developer.github.com/v3/#rate-limiting"
+             TOKEN="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/token.txt"
+             echo "or place github auth token here: $TOKEN"
+             exit 1
+        fi
+        local toc=`echo "$rawhtml" | gh_toc_grab "$gh_src_copy"`
+        echo "$toc"
+        if [ "$need_replace" = "yes" ]; then
+            if grep -Fxq "<!--ts-->" $gh_src && grep -Fxq "<!--te-->" $gh_src; then
+                echo "Found markers"
+            else
+                echo "You don't have <!--ts--> or <!--te--> in your file...exiting"
+                exit 1
+            fi
+            local ts="<\!--ts-->"
+            local te="<\!--te-->"
+            local dt=`date +'%F_%H%M%S'`
+            local ext=".orig.${dt}"
+            local toc_path="${gh_src}.toc.${dt}"
+            local toc_footer="<!-- Added by: `whoami`, at: `date` -->"
+            # http://fahdshariff.blogspot.ru/2012/12/sed-mutli-line-replacement-between-two.html
+            # clear old TOC
+            sed -i${ext} "/${ts}/,/${te}/{//!d;}" "$gh_src"
+            # create toc file
+            echo "${toc}" > "${toc_path}"
+            echo -e "\n${toc_footer}\n" >> "$toc_path"
+            # insert toc file
+            if [[ "`uname`" == "Darwin" ]]; then
+                sed -i "" "/${ts}/r ${toc_path}" "$gh_src"
+            else
+                sed -i "/${ts}/r ${toc_path}" "$gh_src"
+            fi
+            echo
+            echo "!! TOC was added into: '$gh_src'"
+            echo "!! Origin version of the file: '${gh_src}${ext}'"
+            echo "!! TOC added into a separate file: '${toc_path}'"
+            echo
+        fi
+    fi
+}
+
+#
+# Grabber of the TOC from rendered html
+#
+# $1 — a source url of document.
+# It's need if TOC is generated for multiple documents.
+#
+gh_toc_grab() {
+	# if closed <h[1-6]> is on the new line, then move it on the prev line
+	# for example:
+	# 	was: The command <code>foo1</code>
+	# 		 </h1>
+	# 	became: The command <code>foo1</code></h1>
+    sed -e ':a' -e 'N' -e '$!ba' -e 's/\n<\/h/<\/h/g' |
+    # find strings that corresponds to template
+    grep -E -o '<a.*id="user-content-[^"]*".*</h[1-6]' |
+    # remove code tags
+    sed 's/<code>//g' | sed 's/<\/code>//g' |
+    # now all rows are like:
+    #   <a id="user-content-..." href="..."><span ...></span></a> ... </h1
+    # format result line
+    #   * $0 — whole string
+    #   * last element of each row: "</hN" where N in (1,2,3,...)
+    echo -e "$(awk -v "gh_url=$1" '{
+    level = substr($0, length($0), 1)
+    text = substr($0, match($0, /a>.*<\/h/)+2, RLENGTH-5)
+    href = substr($0, match($0, "href=\"[^\"]+?\"")+6, RLENGTH-7)
+    print sprintf("%*s", level*3, " ") "* [" text "](" gh_url  href ")" }' |
+        sed 'y/+/ /; s/%/\\x/g')"
+}
+
+#
+# Returns filename only from full path or url
+#
+gh_toc_get_filename() {
+    echo "${1##*/}"
+}
+
+#
+# Options hendlers
+#
+gh_toc_app() {
+    local need_replace="no"
+
+    if [ "$1" = '--help' ] || [ $# -eq 0 ] ; then
+        local app_name=$(basename "$0")
+        echo "GitHub TOC generator ($app_name): $gh_toc_version"
+        echo ""
+        echo "Usage:"
+        echo "  $app_name [--insert] src [src]  Create TOC for a README file (url or local path)"
+        echo "  $app_name -                     Create TOC for markdown from STDIN"
+        echo "  $app_name --help                Show help"
+        echo "  $app_name --version             Show version"
+        return
+    fi
+
+    if [ "$1" = '--version' ]; then
+        echo "$gh_toc_version"
+        echo
+        echo "os:     `lsb_release -d | cut -f 2`"
+        echo "kernel: `cat /proc/version`"
+        echo "shell:  `$SHELL --version`"
+        echo
+        for tool in curl wget grep awk sed; do
+            printf "%-5s: " $tool
+            echo `$tool --version | head -n 1`
+        done
+        return
+    fi
+
+    if [ "$1" = "-" ]; then
+        if [ -z "$TMPDIR" ]; then
+            TMPDIR="/tmp"
+        elif [ -n "$TMPDIR" -a ! -d "$TMPDIR" ]; then
+            mkdir -p "$TMPDIR"
+        fi
+        local gh_tmp_md
+        gh_tmp_md=$(mktemp $TMPDIR/tmp.XXXXXX)
+        while read input; do
+            echo "$input" >> "$gh_tmp_md"
+        done
+        gh_toc_md2html "$gh_tmp_md" | gh_toc_grab ""
+        return
+    fi
+
+    if [ "$1" = '--insert' ]; then
+        need_replace="yes"
+        shift
+    fi
+
+    for md in "$@"
+    do
+        echo ""
+        gh_toc "$md" "$#" "$need_replace"
+    done
+
+    echo ""
+    echo "Created by [gh-md-toc](https://github.com/ekalinin/github-markdown-toc)"
+}
+
+#
+# Entry point
+#
+gh_toc_app "$@"

--- a/message-format.md
+++ b/message-format.md
@@ -1,87 +1,45 @@
 # FIMP message format 
 
-## FIMP topic format format
+Messages send using FIMP are JSON messages containing the following properties:
 
-### Device service topic
+Property | Type                | Required | Description               
+---------|---------------------|----------|------------
+corid    | String              | No       | Message correlation id. Used for request - response matching.
+ctime    | String              | Yes      | Message creation time, e.g. `"2019-05-31 17:36:31 +0200"`
+props    | Map<String, String> | Yes      | Map of properties.
+resp_to  | String              | No*      | Response topic where requester will expect to receive response.
+serv     | String              | Yes      | Service name the interface is part of.
+src      | String              | Yes      | Source or of the message, should be set only for commands.
+tags     | List<String>        | No       | List of tags.
+type     | String              | Yes      | Interface type, defines message format.
+uid      | String              | Yes      | Unique message identifier.
+val      | dynamic             | Yes      | "payload" - type is defined by `val_t`.
+val_t    | String              | Yes      | Data format of `val` field. See below.
+ver      | String              | Yes      | Version of the message format, default: `"1"`.
 
-pt:j1/mt:evt/rt:dev/rn:zw/ad:1/sv:sensor_presence/ad:16_0
+\*Required for Prime Fimp messages.
 
-pt:j1/mt:cmd/rt:dev/rn:zw/ad:1/sv:out_bin_switch/ad:15_0
+Since `val` can be any type, `val_t` defines what type it is. List of supported `val` types: 
 
-### Technology adapter topic
+`val_t`     | Sample `val`
+------------|-------------
+string      | `'Hello world!'`
+int         | `3`
+float       | `3.1415`
+bool        | `true`
+null        | `null`
+str_array   | `['hello, 'world']`
+int_array   | `[0, 1, 1, 2, 3, 5, 8, 13]`
+float_array | `[3.14, 2.71]`
+int_map     | `{"answer": 42}`
+str_map     | `{"ip": "192.168.1.1"}`
+float_map   | `{"pi: 3.14"}`
+bool_map    | `{"normalityRestored": true}`
+object*     | `{"nested": {"objects": "supported"}}`
+base64      | `U28gbG9uZywgYW5kIHRoYW5rcyBmb3IgYWxsIHRoZSBmaXNoLg==`
 
-pt:j1/mt:evt/rt:app/rn:cloud-bridge/ad:1
+\*A complex object which can't be mapped to primitive types. The structure of an object is defined by interface type and is unique for every interface type. 
 
-pt:j1/mt:cmd/rt:app/rn:cloud-bridge/ad:1
+# Example messages
 
-### Application topic 
-
-pt:j1/mt:evt/rt:ad/rn:zigbee/ad:1
-
-pt:j1/mt:cmd/rt:ad/rn:zigbee/ad:1
-
-### Cloud API topic 
-
-pt:j1/mt:evt/rt:cloud/rn:auth-api/ad:1
-
-pt:j1/mt:cmd/rt:cloud/rn:auth-api/ad:1
-
-### FIMP JSON format. 
- 
-Fields:
-
-Property | Type                |Required | Desc               
----------|---------------------|---------|----------------------------------------------------------------
-type     | String              | Yes     | Interface type, defines message format.
-serv     | String              | Yes     | Service name the interface is part of.
-val_t    | String              | Yes     | Data format of `val` field. See below.
-val      | dynamic             | Yes     | "payload" - it can be either simple type or complex object.
-tags     | List<String>        | No      | List of tags.
-props    | Map<String, String> | Yes     | Map of properties.
-ctime    | String              | Yes     | Message creation time, e.g. `"2019-05-31 17:36:31 +0200"`
-ver      | String              | Yes     | Version of the message format, default: `"1"`.
-uid      | String              | Yes     | Unique message identifier.
-corid    | String              | No      | Message correlation id. Used for request - response matching.
-src      | String              | Yes     | Source or of the message, should be set only for commands.
-resp_to  | String              | No*     | Response topic where requester will expect to receive response.
-
-* Required for Prime Fimp messages.
-
-List of supported `val` types: 
-
-* string
-* int
-* float 
-* bool
-* null
-* str_array
-* int_array
-* float_array
-* int_map
-* str_map
-* float_map
-* bool_map
-* object - A complex object which can't be mapped to primitive types. The structure of an object is defined by interface type and is unique for every interface type. 
-* base64
-
-Message example: 
-
-```json
-{
-   "type": "evt.sensor.report",
-   "serv": "temp_sensor",
-   "val_t": "float",
-   "val": 21.5,
-   "tags": ["tag1", "alarm"],
-   "props": {
-     "prop1": "4",
-     "prop2": "6"
-   },
-   "ctime": "2016-12-21T13:34:14.085581515+01:00",
-   "ver": "1.0",
-   "uid": "fb033c27-e7b5-4834-97ec-632ccb987e9e",
-   "corid": "uid_of_request",
-   "src": "vinculum",
-   "resp_to": "/pt:j1/mt:rsp/rn:smarthome-app/ad:1"
-}
-```
+TODO(alivinco): add sample FIMP messages.


### PR DESCRIPTION
Cleaned up the formatting and spelling of the readme file, and went through it all being as meticulous as possible as we'll have to use it extensively moving forwards with the new client. 

I made some changes, but I have some questions about additional things I would like to change:

Typos:

1. There's something called `alarm_applience`. Is this a typo in the docs or a typo in the implementation? Can this be changed to `alarm_appliance`? If yes, good. If no, we should add a comment to the docs about the typo and pref. work towards fixing it.

2. There's a supported status named `activ` and `deactiv`. Is this a typo? Can this be changed to `active` and `deactive`? If yes, good. If no, we should add a comment to the docs about the typo and pref. work towards fixing it.

3. There's an event called `spinnning`. Is this a typo? Can this be changed to `spinning`? If yes, good. If no, we should add a comment to the docs about the typo and pref. work towards fixing it.

4. There's a unit called `galon`. Is this a typo? Can this be changed to `gallon`? If yes, good. If no, we should add a comment to the docs about the typo and pref. work towards fixing it.

Other: 

1. There are quite a few sensors services, but for some reason. `sensor_contact` and `sensor_presence` are listed separately. Why is this? Can they be merged with the rest of the sensors? If the reason is that they report value of bool instead of float, can't we create a category for binary sensors, just like we have numeric sensors?

2. For some services, props are listed, but it seems like only some of them are listed. For example `out_lvl_switch`: there are three props listed, but there are also properties associated with the interfaces themselves? Is there perhaps a better way this can be structured?

3. The value example for the `sw_type` props for `out_lvl_switch` service is a bit confusing. I'm assuming it should be just one string or can it be an array of strings?