### PR TITLE
SDU-1861 documentation for sub_value property within 'storage' proper…

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,6 +593,30 @@ Modes: off, heat, cool, auto, aux_heat, resume, fan, furnace, dry_air, moist_air
 
 Set-point types: heat, cool, furnace, dry_air, moist_air, auto_changeover, energy_heat, energy_cool, special_heat.
 
+#### Interface storage
+
+Name        | Value example | Description
+------------|---------------|-------------
+`sub_value` | "heat"        | With usage of sub_value, Vinculum will know that it has to store separate temperature for every mode of given thermostat temperature.
+
+#### Examples
+```json
+{
+    "val_t": "str_map",
+    "val": {"type": "heat", "temp": 22.0,"unit": "C" },
+    "storage": {
+       "sub_value": "heat"
+    }
+}
+{
+    "val_t": "str_map",
+    "val": {"type": "cool", "temp": 20.0,"unit": "C" },
+    "storage": {
+       "sub_value": "cool"
+    }
+}
+```
+
 ### Water heater service
 
 #### Service names


### PR DESCRIPTION
The idea figured out right with Christer was to differentiate that information from "props", because it fulfills completelly different role in an mqtt messege. 
This information is not a typical property. It says how to persistently store message's val in Vinculum's State Storage.