### PR TITLE
Add virtual energy service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1384,6 +1384,50 @@ out  | evt.ota_end.report      | object     | Sent on upgrade end with upgrade s
    }
 }
 ```
+### Virtual energy service
+
+The service allows devices with output binary switch service or thermostat service to report accumulated energy consumption in case they do not have their own electric measurement or metering service. Thank to this service delivered energy is calculated based on manually provided power of a device. A device shall calculate energy at every relay state change, mode change or at least every interval value - 30 minutes by default. When service is added on a device, service meter_elec is created. service to send measurements.
+
+#### Service names
+
+`virtual_energy`
+
+#### Interfaces
+
+Type | Interface                | Value type |   Unit  | Description
+-----|--------------------------|------------|---------|------------
+in   | cmd.set_interval         | int        | minutes | Interval  for energy recalculation. Overwrites a default value.
+in   | cmd.add                  | int_map    | watts   | Adds Virtual energy service to a selected device to report energy consumption. Map of integers shall provide power use for every mode.
+in   | cmd.remove_device        | null       |         | Removes Virtual energy service from a selected device. The device shall not be reporting energy consumption.
+
+#### Examples
+
+Adding Virtual energy service on a device working in a one of three available modes (eg. 0-standby, 1-heating, 2-fan):
+
+```json
+{
+   "type": "cmd.add_device",
+   "serv": "virtual_energy",
+   "val_t": "int_map",
+   "val": {
+      "off": 10,
+      "heat": 1500,
+      "fan": 250
+   }
+}
+```
+
+Virtual energy service measurement reporting energy delivered value equal 123.5 kWh:
+
+```json
+{
+   "type": "evt.meter.report",
+   "serv": "meter_elec",
+   "val_t": "float",
+   "val": { 123.5 },
+   "props": {"unit": "kWh", "virtual" : "true"}
+}
+```
 
 ### Technology specific service
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@
    * [Battery charge controller service](#battery-charge-controller-service)
    * [Gateway service](#gateway-service)
    * [Version service](#version-service)
+   * [Virtual meter service](#virtual-meter-service)
    * [Logging service](#logging-interfaces)
 
 
@@ -329,7 +330,7 @@ Name         | Value example | Description
 `prv_data`   |               | Previous meter reading.
 `unit`       | "kWh"         | One of sup_units. For meter_unknown it will be a number.
 `direction`  | "export"      | Defines whether reading is based on consumption (import) or production (export). Applicable for every meter except for meter_elec.
-`virtual`    | "true"        | "true" informs that energy measurement was calculated by Virtual energy service. "false" has the same meaning as if the filed is not present.
+`virtual`    | "elec"        | If present, then the measurement was calculated by a virtual service. Allowed options: "elec", "gas", "water", "heating", "cooling".
 
 #### Important notes
 
@@ -1385,30 +1386,30 @@ out  | evt.ota_end.report      | object     | Sent on upgrade end with upgrade s
    }
 }
 ```
-### Virtual energy service
+### Virtual meter service
 
 The service allows devices with output binary switch service or thermostat service to report accumulated energy consumption in case they do not have their own electric measurement or metering service. Thank to this service delivered energy is calculated based on manually provided power of a device. A device shall calculate energy at every relay state change, mode change or at least every interval value - 30 minutes by default. When service is added on a device, service meter_elec is created. service to send measurements.
 
 #### Service names
 
-`virtual_energy`
+`meter_virtual`
 
 #### Interfaces
 
 Type | Interface                | Value type |   Unit  | Description
 -----|--------------------------|------------|---------|------------
 in   | cmd.set_interval         | int        | minutes | Interval  for energy recalculation. Overwrites a default value.
-in   | cmd.add                  | int_map    | watts   | Adds Virtual energy service to a selected device to report energy consumption. Map of integers shall provide power use for every mode.
-in   | cmd.remove_device        | null       |         | Removes Virtual energy service from a selected device. The device shall not be reporting energy consumption.
+in   | cmd.add                  | int_map    | watts   | Adds Virtual meter service to a selected device to report energy consumption. Map of integers shall provide power use for every mode.
+in   | cmd.remove               | null       |         | Removes Virtual meter service from a selected device. The device shall not be reporting energy consumption.
 
 #### Examples
 
-Adding Virtual energy service on a device working in a one of three available modes "off", "heat" or "fan":
+Adding Virtual meter service on a device working in a one of three available modes "off", "heat" or "fan":
 
 ```json
 {
    "type": "cmd.add_device",
-   "serv": "virtual_energy",
+   "serv": "meter_virtual",
    "val_t": "int_map",
    "val": {
       "off": 10,
@@ -1418,7 +1419,7 @@ Adding Virtual energy service on a device working in a one of three available mo
 }
 ```
 
-Virtual energy service measurement reporting energy delivered value equal 123.5 kWh:
+Virtual meter service measurement reporting energy delivered value equal 123.5 kWh:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ Name         | Value example | Description
 `prv_data`   |               | Previous meter reading.
 `unit`       | "kWh"         | One of sup_units. For meter_unknown it will be a number.
 `direction`  | "export"      | Defines whether reading is based on consumption (import) or production (export). Applicable for every meter except for meter_elec.
-`virtual`    | "elec"        | Field is presend if the measurement was calculated by a virtual service. Allowed options: "elec", "gas", "water", "heating", "cooling".
+`virtual`    | "true"        | Field is present and equal "true' if the measurement was calculated by a virtual service. "false" or not being present have equal meaning.
 
 #### Important notes
 

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ Name         | Value example | Description
 `prv_data`   |               | Previous meter reading.
 `unit`       | "kWh"         | One of sup_units. For meter_unknown it will be a number.
 `direction`  | "export"      | Defines whether reading is based on consumption (import) or production (export). Applicable for every meter except for meter_elec.
-`virtual`    | "elec"        | If present, then the measurement was calculated by a virtual service. Allowed options: "elec", "gas", "water", "heating", "cooling".
+`virtual`    | "elec"        | Field is presend if the measurement was calculated by a virtual service. Allowed options: "elec", "gas", "water", "heating", "cooling".
 
 #### Important notes
 

--- a/README.md
+++ b/README.md
@@ -329,6 +329,7 @@ Name         | Value example | Description
 `prv_data`   |               | Previous meter reading.
 `unit`       | "kWh"         | One of sup_units. For meter_unknown it will be a number.
 `direction`  | "export"      | Defines whether reading is based on consumption (import) or production (export). Applicable for every meter except for meter_elec.
+`virtual`    | "true"        | "true" informs that energy measurement was calculated by Virtual energy service. "false" has the same meaning as if the filed is not present.
 
 #### Important notes
 

--- a/README.md
+++ b/README.md
@@ -1388,7 +1388,7 @@ out  | evt.ota_end.report      | object     | Sent on upgrade end with upgrade s
 ```
 ### Virtual meter service
 
-The service allows devices with output binary switch service or thermostat service to report accumulated energy consumption in case they do not have their own electric measurement or metering service. Thank to this service delivered energy is calculated based on manually provided power of a device. A device shall calculate energy at every relay state change, mode change or at least every interval value - 30 minutes by default. When service is added on a device, service meter_elec is created. service to send measurements.
+This service enables a device to report accumulated consumption in case it does not have its own metering capabilities (eg. a relay with output binary switch service or thermostat). Thanks to the service accumulated consumption is calculated based on manually provided consumption in a unit of time (eg. watts, m3/h). A device shall calculate cumulated consumption at every state's change, mode change and at least every interval value - 30 minutes by default. When this service is added on a device, appropriate metering service is created (eg. meter_elec, meter_water) and a device starts to send measurements.
 
 #### Service names
 
@@ -1399,9 +1399,15 @@ The service allows devices with output binary switch service or thermostat servi
 Type | Interface                | Value type |   Unit  | Description
 -----|--------------------------|------------|---------|------------
 in   | cmd.set_interval         | int        | minutes | Interval  for energy recalculation. Overwrites a default value.
-in   | cmd.add                  | int_map    | watts   | Adds Virtual meter service to a selected device to report energy consumption. Map of integers shall provide power use for every mode.
-in   | cmd.remove               | null       |         | Removes Virtual meter service from a selected device. The device shall not be reporting energy consumption.
+in   | cmd.add                  | int_map    | define by `unit` props   | Adds Virtual meter service to a selected device to report consumption. Map of integers shall provide power use for every mode.
+in   | cmd.remove               | null       |         | Removes Virtual meter service from a selected device. The device shall not be reporting consumption.
 
+  #### Interface props
+
+Name         | Value example | Description
+-------------|---------------|-------------
+`unit`       | "kWh"         | One of sup_units. For meter_unknown it will be a number.
+  
 #### Examples
 
 Adding Virtual meter service on a device working in a one of three available modes "off", "heat" or "fan":

--- a/README.md
+++ b/README.md
@@ -1412,7 +1412,7 @@ Name         | Value example | Description
 
 Name                | Value example                                                   | Description
 --------------------|-----------------------------------------------------------------|-------------
-`sup_units`         | ["W", "kW", "m3/h"]                                             | List of supported units.
+`sup_units`         | ["W"]                                                           | List of supported units. 
 `sup_modes`         | ["on", "off"] for relay, ["off", "heat", "cool"] for thermostat | List of supported modes.
   
 #### Examples

--- a/README.md
+++ b/README.md
@@ -1398,15 +1398,15 @@ This service enables a device to report accumulated consumption in case it does 
 
 Type | Interface                | Value type |   Unit  | Description
 -----|--------------------------|------------|---------|------------
-in   | cmd.set_interval         | int        | minutes | Interval  for energy recalculation. Overwrites a default value.
-in   | cmd.add                  | int_map    | define by `unit` props   | Adds Virtual meter service to a selected device to report consumption. Map of integers shall provide power use for every mode.
-in   | cmd.remove               | null       |         | Removes Virtual meter service from a selected device. The device shall not be reporting consumption.
+in   | cmd.set_interval         | int        | minutes | Interval  for accumulated consumption recalculation. Overwrites a default value.
+in   | cmd.add                  | int_float  | define by `unit` props   | Adds Virtual meter service to a selected device to report accumulated consumption. Map of floats shall provide consumption for every mode.
+in   | cmd.remove               | null       |         | Removes Virtual meter service from a selected device. The device shall not be reporting accumulated consumption.
 
   #### Interface props
 
 Name         | Value example | Description
 -------------|---------------|-------------
-`unit`       | "kWh"         | One of sup_units. For meter_unknown it will be a number.
+`unit`       | "W", "m3/h"   |  Consumption
   
 #### Examples
 
@@ -1416,7 +1416,7 @@ Adding Virtual meter service on a device working in a one of three available mod
 {
    "type": "cmd.add_device",
    "serv": "meter_virtual",
-   "val_t": "int_map",
+   "val_t": "int_float",
    "val": {
       "off": 10,
       "heat": 1500,

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ Name         | Value example | Description
 `prv_data`   |               | Previous meter reading.
 `unit`       | "kWh"         | One of sup_units. For meter_unknown it will be a number.
 `direction`  | "export"      | Defines whether reading is based on consumption (import) or production (export). Applicable for every meter except for meter_elec.
-`virtual`    | "true"        | Field is present and equal "true" if the measurement was calculated by a virtual service. "false" or not being present have equal meaning.
+`virtual`    | "true"        | Field is present and equal "true" if the measurement was calculated by a virtual service, and "false" or not being present otherwise.
 
 #### Important notes
 
@@ -1388,17 +1388,17 @@ out  | evt.ota_end.report      | object     | Sent on upgrade end with upgrade s
 ```
 ### Virtual meter service
 
-This service enables a device to report accumulated consumption and/or pulses in case it does not have its own metering capabilities (eg. a relay with output binary switch service or thermostat accumulating pulses (watts) into consumption(kWh)). For every existing meter_X service corresponging virtual_meter_X service can be created (eg. virtual_meter_elec will create meter_elec) to report accumulated consumption using manually provided consumption per unit of time (pulses). The service shall calculate cumulated consumption at every state's change, mode change and at least every interval value multiplying this interval by pulses and send measurements.
+This service enables a device to report accumulated consumption and/or pulses in case it does not have its own metering capabilities (eg. a relay with output binary switch service or thermostat accumulating momentary power measured in Watts into energy consumption measured in kWh). If a virtual meter service is present in a device, upon manual configuration providing a consumption per supported unit, a proper meter service will be added to the device. The service then will calculate cumulated consumption at every state change, mode change and at least once during a configured interval.
 
 #### Service names
 
-`virtual_meter_[type]`
+`virtual_meter_elec`
 
 #### Interfaces
 
 Type | Interface                      | Value type |  Props  | Description
 -----|----------------------------- --|------------|---------|------------
-in   | cmd.meter.set_interval         | int        |         | Interval in minutes for accumulated consumption recalculation. Overwrites a default value 30 minutes.
+in   | cmd.meter.set_interval         | int        |         | Interval in minutes for accumulated consumption recalculation. Overwrites a default value of 30 minutes.
 in   | cmd.meter.add                  | float_map  | `unit`  | Adds corresponding meter service (eg. meter_elec) to a selected device to report accumulated consumption. Map of floats shall provide consumption for every mode.
 in   | cmd.meter.remove               | null       |        | Removes all added virtual meter services from a selected device. The device shall not be reporting accumulated consumption nor pulses anymore.
 
@@ -1406,7 +1406,7 @@ in   | cmd.meter.remove               | null       |        | Removes all added 
 
 Name         | Value example | Description
 -------------|---------------|-------------
-`unit`       | "W", "m3/h"   | Pulse's unit - Consumption per unit of time
+`unit`       | "W", "m3/h"   | Pulse's unit - consumption per unit of time.
 
 #### Service props
 
@@ -1417,7 +1417,7 @@ Name                | Value example                                             
   
 #### Examples
 
-Adding Virtual meter service on a device working in a one of three available modes "off", "heat" or "fan":
+Adding virtual meter service on a device working in a one of three available modes "off", "heat" or "fan":
 
 ```json
 {
@@ -1435,7 +1435,7 @@ Adding Virtual meter service on a device working in a one of three available mod
 }
 ```
 
-Virtual meter service measurement reporting energy delivered value equal 123.5 kWh:
+Virtual meter service measurement reporting consumed energy value equal 123.5 kWh:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -1406,7 +1406,7 @@ in   | cmd.remove               | null       |         | Removes Virtual meter s
 
 Name         | Value example | Description
 -------------|---------------|-------------
-`unit`       | "W", "m3/h"   |  of energy per unit of time
+`unit`       | "W", "m3/h"   | Consumption per unit of time
   
 #### Examples
 
@@ -1421,6 +1421,9 @@ Adding Virtual meter service on a device working in a one of three available mod
       "off": 10,
       "heat": 1500,
       "fan": 250
+   },
+   "props": {
+      "unit": "W"
    }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ Name         | Value example | Description
 `prv_data`   |               | Previous meter reading.
 `unit`       | "kWh"         | One of sup_units. For meter_unknown it will be a number.
 `direction`  | "export"      | Defines whether reading is based on consumption (import) or production (export). Applicable for every meter except for meter_elec.
-`virtual`    | "true"        | Field is present and equal "true' if the measurement was calculated by a virtual service. "false" or not being present have equal meaning.
+`virtual`    | "true"        | Field is present and equal "true" if the measurement was calculated by a virtual service. "false" or not being present have equal meaning.
 
 #### Important notes
 
@@ -1388,7 +1388,7 @@ out  | evt.ota_end.report      | object     | Sent on upgrade end with upgrade s
 ```
 ### Virtual meter service
 
-This service enables a device to report accumulated consumption in case it does not have its own metering capabilities (eg. a relay with output binary switch service or thermostat). Thanks to the service accumulated consumption is calculated based on manually provided consumption in a unit of time (eg. watts, m3/h). A device shall calculate cumulated consumption at every state's change, mode change and at least every interval value - 30 minutes by default. When this service is added on a device, appropriate metering service is created (eg. meter_elec, meter_water) and a device starts to send measurements.
+This service enables a device to report accumulated consumption in case it does not have its own metering capabilities (eg. a relay with output binary switch service or thermostat). Thanks to the service accumulated consumption is calculated based on manually provided consumption per unit of time (eg. watts, m3/h). The service shall calculate cumulated consumption at every state's change, mode change and at least every interval value. When this service is added on a device, appropriate metering service is created (eg. meter_elec, meter_water) and the service starts to send measurements.
 
 #### Service names
 
@@ -1396,17 +1396,17 @@ This service enables a device to report accumulated consumption in case it does 
 
 #### Interfaces
 
-Type | Interface                | Value type |   Unit  | Description
+Type | Interface                | Value type |  Props  | Description
 -----|--------------------------|------------|---------|------------
-in   | cmd.set_interval         | int        | minutes | Interval  for accumulated consumption recalculation. Overwrites a default value.
-in   | cmd.add                  | int_float  | define by `unit` props   | Adds Virtual meter service to a selected device to report accumulated consumption. Map of floats shall provide consumption for every mode.
+in   | cmd.set_interval         | int        |         | Interval in minutes for accumulated consumption recalculation. Overwrites a default value 30 minutes.
+in   | cmd.add                  | float_map  | `unit`  | Adds Virtual meter service to a selected device to report accumulated consumption. Map of floats shall provide consumption for every mode.
 in   | cmd.remove               | null       |         | Removes Virtual meter service from a selected device. The device shall not be reporting accumulated consumption.
 
   #### Interface props
 
 Name         | Value example | Description
 -------------|---------------|-------------
-`unit`       | "W", "m3/h"   |  Consumption
+`unit`       | "W", "m3/h"   |  of energy per unit of time
   
 #### Examples
 
@@ -1414,7 +1414,7 @@ Adding Virtual meter service on a device working in a one of three available mod
 
 ```json
 {
-   "type": "cmd.add_device",
+   "type": "cmd.add",
    "serv": "meter_virtual",
    "val_t": "int_float",
    "val": {

--- a/README.md
+++ b/README.md
@@ -1407,6 +1407,13 @@ in   | cmd.remove               | null       |         | Removes corresponding m
 Name         | Value example | Description
 -------------|---------------|-------------
 `unit`       | "W", "m3/h"   | Consumption per unit of time
+
+#### Service props
+
+Name                | Value example                                                   | Description
+--------------------|-----------------------------------------------------------------|-------------
+`sup_units`         | ["W", "kW", "m3/h"]                                             | List of supported units.
+`sup_modes`         | ["on", "off"] for relay, ["off", "heat", "cool"] for thermostat | List of supported modes.
   
 #### Examples
 

--- a/README.md
+++ b/README.md
@@ -1392,7 +1392,7 @@ This service enables a device to report accumulated consumption and/or pulses in
 
 #### Service names
 
-`virtual_meter_X`
+`virtual_meter_[type]`
 
 #### Interfaces
 
@@ -1400,7 +1400,7 @@ Type | Interface                      | Value type |  Props  | Description
 -----|----------------------------- --|------------|---------|------------
 in   | cmd.meter.set_interval         | int        |         | Interval in minutes for accumulated consumption recalculation. Overwrites a default value 30 minutes.
 in   | cmd.meter.add                  | float_map  | `unit`  | Adds corresponding meter service (eg. meter_elec) to a selected device to report accumulated consumption. Map of floats shall provide consumption for every mode.
-in   | cmd.meter.remove               | null       |        | Removes all added virtual meter services from a selected device. The device shall not be reporting accumulated consumption.
+in   | cmd.meter.remove               | null       |        | Removes all added virtual meter services from a selected device. The device shall not be reporting accumulated consumption nor pulses anymore.
 
   #### Interface props
 
@@ -1421,7 +1421,7 @@ Adding Virtual meter service on a device working in a one of three available mod
 
 ```json
 {
-   "type": "cmd.add",
+   "type": "cmd.meter.add",
    "serv": "virtual_meter_elec",
    "val_t": "float_map",
    "val": {

--- a/README.md
+++ b/README.md
@@ -1399,8 +1399,8 @@ This service enables a device to report accumulated consumption in case it does 
 Type | Interface                | Value type |  Props  | Description
 -----|--------------------------|------------|---------|------------
 in   | cmd.set_interval         | int        |         | Interval in minutes for accumulated consumption recalculation. Overwrites a default value 30 minutes.
-in   | cmd.add                  | float_map  | `unit`  | Adds Virtual meter service to a selected device to report accumulated consumption. Map of floats shall provide consumption for every mode.
-in   | cmd.remove               | null       |         | Removes Virtual meter service from a selected device. The device shall not be reporting accumulated consumption.
+in   | cmd.add                  | float_map  | `unit`  | Adds corresponding meter service (eg. meter_elec) to a selected device to report accumulated consumption. Map of floats shall provide consumption for every mode.
+in   | cmd.remove               | null       |         | Removes corresponding meter service from a selected device. The device shall not be reporting accumulated consumption.
 
   #### Interface props
 

--- a/README.md
+++ b/README.md
@@ -1388,25 +1388,25 @@ out  | evt.ota_end.report      | object     | Sent on upgrade end with upgrade s
 ```
 ### Virtual meter service
 
-This service enables a device to report accumulated consumption in case it does not have its own metering capabilities (eg. a relay with output binary switch service or thermostat). Thanks to the service accumulated consumption is calculated based on manually provided consumption per unit of time (eg. watts, m3/h). The service shall calculate cumulated consumption at every state's change, mode change and at least every interval value. When this service is added on a device, appropriate metering service is created (eg. meter_elec, meter_water) and the service starts to send measurements.
+This service enables a device to report accumulated consumption and/or pulses in case it does not have its own metering capabilities (eg. a relay with output binary switch service or thermostat accumulating pulses (watts) into consumption(kWh)). For every existing meter_X service corresponging virtual_meter_X service can be created (eg. virtual_meter_elec will create meter_elec) to report accumulated consumption using manually provided consumption per unit of time (pulses). The service shall calculate cumulated consumption at every state's change, mode change and at least every interval value multiplying this interval by pulses and send measurements.
 
 #### Service names
 
-`meter_virtual`
+`virtual_meter_X`
 
 #### Interfaces
 
-Type | Interface                | Value type |  Props  | Description
------|--------------------------|------------|---------|------------
+Type | Interface                      | Value type |  Props  | Description
+-----|----------------------------- --|------------|---------|------------
 in   | cmd.meter.set_interval         | int        |         | Interval in minutes for accumulated consumption recalculation. Overwrites a default value 30 minutes.
 in   | cmd.meter.add                  | float_map  | `unit`  | Adds corresponding meter service (eg. meter_elec) to a selected device to report accumulated consumption. Map of floats shall provide consumption for every mode.
-in   | cmd.meter.remove               | null       |         | Removes corresponding meter service from a selected device. The device shall not be reporting accumulated consumption.
+in   | cmd.meter.remove               | null       |        | Removes all added virtual meter services from a selected device. The device shall not be reporting accumulated consumption.
 
   #### Interface props
 
 Name         | Value example | Description
 -------------|---------------|-------------
-`unit`       | "W", "m3/h"   | Consumption per unit of time
+`unit`       | "W", "m3/h"   | Pulse's unit - Consumption per unit of time
 
 #### Service props
 
@@ -1422,7 +1422,7 @@ Adding Virtual meter service on a device working in a one of three available mod
 ```json
 {
    "type": "cmd.add",
-   "serv": "meter_virtual",
+   "serv": "virtual_meter_elec",
    "val_t": "float_map",
    "val": {
       "off": 10,

--- a/README.md
+++ b/README.md
@@ -1402,7 +1402,7 @@ in   | cmd.remove_device        | null       |         | Removes Virtual energy 
 
 #### Examples
 
-Adding Virtual energy service on a device working in a one of three available modes (eg. 0-standby, 1-heating, 2-fan):
+Adding Virtual energy service on a device working in a one of three available modes "off", "heat" or "fan":
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -1398,9 +1398,9 @@ This service enables a device to report accumulated consumption in case it does 
 
 Type | Interface                | Value type |  Props  | Description
 -----|--------------------------|------------|---------|------------
-in   | cmd.set_interval         | int        |         | Interval in minutes for accumulated consumption recalculation. Overwrites a default value 30 minutes.
-in   | cmd.add                  | float_map  | `unit`  | Adds corresponding meter service (eg. meter_elec) to a selected device to report accumulated consumption. Map of floats shall provide consumption for every mode.
-in   | cmd.remove               | null       |         | Removes corresponding meter service from a selected device. The device shall not be reporting accumulated consumption.
+in   | cmd.meter.set_interval         | int        |         | Interval in minutes for accumulated consumption recalculation. Overwrites a default value 30 minutes.
+in   | cmd.meter.add                  | float_map  | `unit`  | Adds corresponding meter service (eg. meter_elec) to a selected device to report accumulated consumption. Map of floats shall provide consumption for every mode.
+in   | cmd.meter.remove               | null       |         | Removes corresponding meter service from a selected device. The device shall not be reporting accumulated consumption.
 
   #### Interface props
 

--- a/README.md
+++ b/README.md
@@ -1423,7 +1423,7 @@ Adding Virtual meter service on a device working in a one of three available mod
 {
    "type": "cmd.add",
    "serv": "meter_virtual",
-   "val_t": "int_float",
+   "val_t": "float_map",
    "val": {
       "off": 10,
       "heat": 1500,


### PR DESCRIPTION
I extracted this PR from previous PR https://github.com/futurehomeno/fimp-api/pull/59. Since this service is closely connected to elec_meter (and possibly other XXX_meter) let's call it virtual_meter. It will make it more generic. Let it be just a virtual_meter and whatever it is under the masc - electrical device or water flow meter with on/off valve - it can calculate accumulated consumption of every medium reporting it by  XXX_meter service, depends on a typeof device. We should keep FIMP protocol generic imo and possible flexible to be future proved. It will be an extension for any meter.