### PR TITLE
Barrier control changes.

### DIFF
--- a/device_services/generic/barrier_control.md
+++ b/device_services/generic/barrier_control.md
@@ -11,24 +11,29 @@ The service represent devices like garage doors, barriers, window protection sha
 
 ## Interfaces
 
-| Type | Interface                | Value type | Properties   | Description                                                                                                                                                                              |
-|------|--------------------------|------------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| in   | cmd.notiftype.get_report | null       |              | Requests notification types the device supports when signalling opening/closing of the door.                                                                                             |
-| in   | cmd.notiftype.set        | bool_map   |              | Sets notification type the device is using when signalling opening/closing of the door. Configurable notification types are defined in [`sup_notiftypes`](#service-properties) property. |
-| out  | evt.notiftype.report     | bool_map   |              | Returns notification types the device is using while opening/closing door.                                                                                                               |
-| -    |                          |            |              |                                                                                                                                                                                          |
-| in   | cmd.op.stop              | null       |              | Stops any operation immediatelly.                                                                                                                                                        |
-| -    |                          |            |              |                                                                                                                                                                                          |
-| in   | cmd.state.get_report     | null       |              | Requests the current state of the device.                                                                                                                                                |
-| out  | evt.state.report         | string     | `stopped_at` | Reports the current state of the device, one of values defined in [`sup_states`](#service-properties) property.                                                                          |
-| -    |                          |            |              |                                                                                                                                                                                          |
-| in   | cmd.tstate.set           | string     |              | Sets the target state of the device to the one of values defined in [`sup_tstates`](#service-properties) property.                                                                       |
+| Type | Interface                | Value type | Properties | Description                                                                                                                                                                              |
+|------|--------------------------|------------|------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| in   | cmd.notiftype.get_report | null       |            | Requests notification types the device supports when signalling opening/closing of the door.                                                                                             |
+| in   | cmd.notiftype.set        | bool_map   |            | Sets notification type the device is using when signalling opening/closing of the door. Configurable notification types are defined in [`sup_notiftypes`](#service-properties) property. |
+| out  | evt.notiftype.report     | bool_map   |            | Returns notification types the device is using while opening/closing door.                                                                                                               |
+| -    |                          |            |            |                                                                                                                                                                                          |
+| in   | cmd.op.stop              | null       |            | Stops any operation immediately.                                                                                                                                                         |
+| -    |                          |            |            |                                                                                                                                                                                          |
+| in   | cmd.state.get_report     | null       |            | Requests the current state of the device.                                                                                                                                                |
+| out  | evt.state.report         | string     | `position` | Reports the current state of the device, one of values defined in [`sup_states`](#service-properties) property.                                                                          |
+| -    |                          |            |            |                                                                                                                                                                                          |
+| in   | cmd.tstate.set           | string     | `stop_at`  | Sets the target state of the device to the one of values defined in [`sup_tstates`](#service-properties) property.                                                                       |
 
 ## Interface properties
 
-| Name         | Required | Example | Description                                                                                                                    |
-|--------------|----------|---------|--------------------------------------------------------------------------------------------------------------------------------|
-| `stopped_at` | No       | `"30"`  | Position as percentage value at which the barrier stopped on emergency halt, where `1` is near closed while `99` is near open. |
+| Name       | Required | Example | Description                                                                                                                                    |
+|------------|----------|---------|------------------------------------------------------------------------------------------------------------------------------------------------|
+| `position` | No       | `"30"`  | Position as percentage value at which the barrier stopped on emergency halt or currently is, where `1` is near closed while `99` is near open. |
+| `stop_at`  | No       | `"75"`  | Position as percentage value at which the barrier should stop.                                                                                 |
+
+> Please note that properties `position` and `stop_at` are optional and depend directly on the device capabilities.
+> * Property `stop_at` will be ignored if the device does not support partial opening or closing, which should be indicated by `sup_stop_at` service property.
+> * Property `position` might be present only on "stopped" state report or never if the device does not support live progress reporting.  
 
 ## Service properties
 
@@ -37,6 +42,7 @@ The service represent devices like garage doors, barriers, window protection sha
 | `sup_notiftypes` | str_array | `["audio", "visual"]`                      | List of supported notification types. Allowed values are: `audio`, `visual`.                      |
 | `sup_states`     | str_array | `["open", "closed", "closing", "opening"]` | List of supported states. Allowed values are:  `closed`, `closing`, `stopped`, `opening`, `open`. |
 | `sup_tstates`    | str_array | `["open", "closed"]`                       | List of supported target states. Allowed values are: `closed`, `open`.                            |
+| `sup_stop_at`    | bool      | `true`                                     | Indicates whether the `stop_at` property is supported by `cmd.tstate.set` command.                |
 
 ## Examples
 
@@ -86,7 +92,7 @@ The service represent devices like garage doors, barriers, window protection sha
   "val_t": "string",
   "val": "stopped",
   "props": {
-    "stopped_at": "30"
+    "position": "30"
   },
   "tags": [],
   "src": "-",

--- a/device_services/generic/barrier_control.md
+++ b/device_services/generic/barrier_control.md
@@ -22,18 +22,17 @@ The service represent devices like garage doors, barriers, window protection sha
 | in   | cmd.state.get_report     | null       |            | Requests the current state of the device.                                                                                                                                                |
 | out  | evt.state.report         | string     | `position` | Reports the current state of the device, one of values defined in [`sup_states`](#service-properties) property.                                                                          |
 | -    |                          |            |            |                                                                                                                                                                                          |
-| in   | cmd.tstate.set           | string     | `stop_at`  | Sets the target state of the device to the one of values defined in [`sup_tstates`](#service-properties) property.                                                                       |
+| in   | cmd.tstate.set           | string     | `position` | Sets the target state of the device to the one of values defined in [`sup_tstates`](#service-properties) property.                                                                       |
 
 ## Interface properties
 
-| Name       | Required | Example | Description                                                                                                                                    |
-|------------|----------|---------|------------------------------------------------------------------------------------------------------------------------------------------------|
-| `position` | No       | `"30"`  | Position as percentage value at which the barrier stopped on emergency halt or currently is, where `1` is near closed while `99` is near open. |
-| `stop_at`  | No       | `"75"`  | Position as percentage value at which the barrier should stop.                                                                                 |
+| Name       | Required | Example | Description                                                                    |
+|------------|----------|---------|--------------------------------------------------------------------------------|
+| `position` | No       | `"30"`  | Position as percentage value where `1` is near closed while `99` is near open. |
 
-> Please note that properties `position` and `stop_at` are optional and depend directly on the device capabilities.
-> * Property `stop_at` will be ignored if the device does not support partial opening or closing, which should be indicated by `sup_stop_at` service property.
-> * Property `position` might be present only on "stopped" state report or never if the device does not support live progress reporting.  
+> Please note that property `position` is optional and depend directly on the device capabilities.
+> * Property `position` in `cmd.tstate.set` will be ignored if the device does not support partial opening or closing indicated by `sup_tposition` service property.
+> * Property `position` in `evt.state.report` might be present only on "stopped" state report or never if the device does not support live progress reporting.
 
 ## Service properties
 
@@ -42,7 +41,7 @@ The service represent devices like garage doors, barriers, window protection sha
 | `sup_notiftypes` | str_array | `["audio", "visual"]`                      | List of supported notification types. Allowed values are: `audio`, `visual`.                      |
 | `sup_states`     | str_array | `["open", "closed", "closing", "opening"]` | List of supported states. Allowed values are:  `closed`, `closing`, `stopped`, `opening`, `open`. |
 | `sup_tstates`    | str_array | `["open", "closed"]`                       | List of supported target states. Allowed values are: `closed`, `open`.                            |
-| `sup_stop_at`    | bool      | `true`                                     | Indicates whether the `stop_at` property is supported by `cmd.tstate.set` command.                |
+| `sup_tposition`  | bool      | `true`                                     | Indicates whether the `position` property is supported by `cmd.tstate.set` command.               |
 
 ## Examples
 
@@ -75,6 +74,25 @@ The service represent devices like garage doors, barriers, window protection sha
   "val_t": "string",
   "val": "open",
   "props": {},
+  "tags": [],
+  "src": "-",
+  "ver": "1",
+  "uid": "eb99fe48-3276-4a21-acd4-a6cbfb3a800d",
+  "topic": "pt:j1/mt:cmd/rt:dev/rn:zw/ad:1/sv:barrier_ctrl/ad:50_0"
+}
+```
+
+* Example of a command to open the barrier partially to 50% position:
+
+```json
+{
+  "serv": "barrier_ctrl",
+  "type": "cmd.tstate.set",
+  "val_t": "string",
+  "val": "open",
+  "props": {
+    "position": "50"
+  },
   "tags": [],
   "src": "-",
   "ver": "1",


### PR DESCRIPTION
* Renamed "stopped_at" property to "position" to allow its flexible use. Property has not been yet utilized by the mobile application.
* Added property "stop_at" to command `cmd.tstate.set` which allows partial opening or closing to a certain point.

The changes are mostly backward-compatible besides rename of stopped_at to position. The effectively extend barrier_ctrl service to match out_lvl_switch capabilities with addition of its own dedicated statuses.

Live reporting of the position might be achieved by sending evt.state.report with updated position property.
Closing/Opening to a certain point might be achieved by sending cmd.tstate.set with stop_at property set to desired value.