### PR TITLE
Improper evt.meter.report type

### DIFF
--- a/device_services/generic/virtual_meter.md
+++ b/device_services/generic/virtual_meter.md
@@ -22,7 +22,7 @@ The service then will calculate accumulated consumption at every state change, m
 | in   | cmd.meter.add              | float_map  | `unit`     | Adds corresponding meter service (eg. `meter_elec`) to a selected device and the provided `unit` to report accumulated consumption. Map of floats shall provide consumption for every mode. Every `cmd.meter.add` command overwrites previous. |
 | in   | cmd.meter.remove           | null       |            | Removes all added virtual meter services from a selected device. The device shall not be reporting accumulated consumption nor pulses anymore. If removal was successful sends `evt.meter.report` with empty float map.                        |
 | in   | cmd.meter.get_report       | null       |            | Requests the report of the currently set values for each mode.                                                                                                                                                                                 |
-| out  | evt.meter.report           | float_map  | `unit`     | Reports currently set values for each mode and the provided `unit`.                                                                                                                                                                            |
+| out  | evt.meter.report           | float      | `unit`     | Reports currently set power value.                                                                                                                                                                            |
 
 ## Interface properties
 


### PR DESCRIPTION
code from Zigbee 2.6.15:
```
	energy := float64(ptr.cachedAccCons) / 3600.0 / 1000.0
	props := map[string]string{"unit": "kWh", "virtual": "true"}

	fimpMsg := fimpgo.NewFloatMessage("evt.meter.report", fimpAddr.ServiceName, energy, props, nil, nil)
```
	
example is correct.