### PR TITLE
DEV-2724: Add tunneling commands description

### DIFF
--- a/device_services/_sidebar.md
+++ b/device_services/_sidebar.md
@@ -39,3 +39,4 @@
     - [Time](/device_services/meta/time.md)
     - [Version](/device_services/meta/version.md)
     - [Technology specific](/device_services/meta/technology_specific.md)
+    - [Diagnostic](/device_services/meta/diagnostic.md)

--- a/device_services/device_services.md
+++ b/device_services/device_services.md
@@ -31,6 +31,7 @@ Generic services are each representing an aspect or functionality of a device. T
 - [Siren control](/device_services/generic/siren_control.md)
 - [Media player](/device_services/generic/media_player.md)
 - [Sound switch](/device_services/generic/sound_switch.md)
+- [Diagnostic](/device_services/meta/diagnostic.md)
 
 ## Product specific services
 

--- a/device_services/generic/meter.md
+++ b/device_services/generic/meter.md
@@ -28,35 +28,8 @@ An electricity meter service can represent a stand-alone AMS meter, like a HAN s
 | -    |                             |            |                                          |             |             |                                                                                                                                                                                     |
 | in   | cmd.meter_ext.get_report    | str_array  |                                          |             |             | Requests an extended electricity report for listed extended values. Empty or null value requests all supported extended values.                                                     |
 | out  | evt.meter_ext.report        | float_map  |                                          | `split`     |             | Returns an extended electricity report. See [electricity measurements](#electricity-measurements) section for more information.                                                     |
-| -    |                             |            |                                          |             |             |                                                                                                                                                                                     |
-| out  | cmd.meter_log.start         | object     |                                          |             |             | Request thing to open a tunnel to metering device and adapter to start logging received data. see [`tunnel_request`](#definitions).                                                 |
-| out  | cmd.meter_log.stop          | null       |                                          |             |             | Request thing to close the tunnel and adapter to conclude the log. Tunnel should be closed when not needed because of network load management.                                      |
 
 > For backward compatibility the service reports imported/consumed values using `evt.meter.report` interface and exported/produced values using `evt.meter_export.report`.
-
-## Definitions
-
-* `tunnel request` is an object with following structure:
-
-| Field         | Type   | Example                              | Description                                                                                            |
-|---------------|--------|--------------------------------------|--------------------------------------------------------------------------------------------------------|
-| `protocol`    | int    | `3`                                  | ID of protocol which will be tunneled from device to adapter see [`tunneling_protocols`](#definitions) |
-
-* `tunneling_protocols`
-
-| ID        | Description                    |
-|-----------|--------------------------------|
-| `0`       | DLMS/COSEM (IEC 62056)         |
-| `1`       | IEC 61107                      |
-| `2`       | ANSI C12                       |
-| `3`       | M-BUS                          |
-| `4`       | SML                            |
-| `5`       | ClimateTalk                    |
-| `6`       | GB-HRGP                        |
-| `7`       | IP v4                          |
-| `8`       | IP v6                          |
-| `200-254` | Manufacturer defined protocols |
-
 
 ## Interface properties
 
@@ -149,24 +122,6 @@ An electricity meter service can represent a stand-alone AMS meter, like a HAN s
   },
   "storage": {
     "strategy": "split"
-  },
-  "props": null,
-  "tags": null,
-  "src": "-",
-  "ver": "1",
-  "uid": "e604e951-7afb-4f96-981b-62e905757686",
-  "topic": "pt:j1/mt:evt/rt:dev/rn:zigbee/ad:1/sv:meter_elec/ad:1_2"
-}
-```
-* Open a tunnel to an AMS through Futurehome HAN NVE
-
-```json
-{
-  "serv": "meter_elec",
-  "type": "evt.meter_log.start",
-  "val_t": "object",
-  "val": {
-    "protocol": 3
   },
   "props": null,
   "tags": null,

--- a/device_services/generic/meter.md
+++ b/device_services/generic/meter.md
@@ -40,8 +40,6 @@ An electricity meter service can represent a stand-alone AMS meter, like a HAN s
 
 | Field         | Type   | Example                              | Description                                                                                            |
 |---------------|--------|--------------------------------------|--------------------------------------------------------------------------------------------------------|
-| `udid`        | int    | `1`                                  | Thing unique ID                                                                                        |
-| `group`       | string | `1`                                  | Group unique ID [for Zigbee devices it will correspond to endpoint with tunneling cluster]             |
 | `protocol`    | int    | `3`                                  | ID of protocol which will be tunneled from device to adapter see [`tunneling_protocols`](#definitions) |
 
 * `tunneling_protocols`
@@ -168,8 +166,6 @@ An electricity meter service can represent a stand-alone AMS meter, like a HAN s
   "type": "evt.meter_log.start",
   "val_t": "object",
   "val": {
-    "udid": 1,
-    "group": 1,
     "protocol": 3
   },
   "props": null,

--- a/device_services/generic/meter.md
+++ b/device_services/generic/meter.md
@@ -28,8 +28,37 @@ An electricity meter service can represent a stand-alone AMS meter, like a HAN s
 | -    |                             |            |                                          |             |             |                                                                                                                                                                                     |
 | in   | cmd.meter_ext.get_report    | str_array  |                                          |             |             | Requests an extended electricity report for listed extended values. Empty or null value requests all supported extended values.                                                     |
 | out  | evt.meter_ext.report        | float_map  |                                          | `split`     |             | Returns an extended electricity report. See [electricity measurements](#electricity-measurements) section for more information.                                                     |
+| -    |                             |            |                                          |             |             |                                                                                                                                                                                     |
+| out  | cmd.meter_log.start         | object     |                                          |             |             | Request thing to open a tunnel to metering device and adapter to start logging received data. see [`tunnel_request`](#definitions).                                                 |
+| out  | cmd.meter_log.stop          | null       |                                          |             |             | Request thing to close the tunnel and adapter to conclude the log. Tunnel should be closed when not needed because of network load management.                                      |
 
 > For backward compatibility the service reports imported/consumed values using `evt.meter.report` interface and exported/produced values using `evt.meter_export.report`.
+
+## Definitions
+
+* `tunnel request` is an object with following structure:
+
+| Field         | Type   | Example                              | Description                                                                                            |
+|---------------|--------|--------------------------------------|--------------------------------------------------------------------------------------------------------|
+| `udid`        | int    | `1`                                  | Thing unique ID                                                                                        |
+| `group`       | string | `1`                                  | Group unique ID [for Zigbee devices it will correspond to endpoint with tunneling cluster]             |
+| `protocol`    | int    | `3`                                  | ID of protocol which will be tunneled from device to adapter see [`tunneling_protocols`](#definitions) |
+
+* `tunneling_protocols`
+
+| ID        | Description                    |
+|-----------|--------------------------------|
+| `0`       | DLMS/COSEM (IEC 62056)         |
+| `1`       | IEC 61107                      |
+| `2`       | ANSI C12                       |
+| `3`       | M-BUS                          |
+| `4`       | SML                            |
+| `5`       | ClimateTalk                    |
+| `6`       | GB-HRGP                        |
+| `7`       | IP v4                          |
+| `8`       | IP v6                          |
+| `200-254` | Manufacturer defined protocols |
+
 
 ## Interface properties
 
@@ -122,6 +151,26 @@ An electricity meter service can represent a stand-alone AMS meter, like a HAN s
   },
   "storage": {
     "strategy": "split"
+  },
+  "props": null,
+  "tags": null,
+  "src": "-",
+  "ver": "1",
+  "uid": "e604e951-7afb-4f96-981b-62e905757686",
+  "topic": "pt:j1/mt:evt/rt:dev/rn:zigbee/ad:1/sv:meter_elec/ad:1_2"
+}
+```
+* Open a tunnel to an AMS through Futurehome HAN NVE
+
+```json
+{
+  "serv": "meter_elec",
+  "type": "evt.meter_log.start",
+  "val_t": "object",
+  "val": {
+    "udid": 1,
+    "group": 1,
+    "protocol": 3
   },
   "props": null,
   "tags": null,

--- a/device_services/meta/diagnostic.md
+++ b/device_services/meta/diagnostic.md
@@ -10,7 +10,7 @@ This service allows for the control of diagnostic functionalities of associated 
 
 | Type | Interface                  | Value type | Properties         | Description                                                                                                                                                                                              |
 |------|----------------------------|------------|--------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| out  | cmd.log.start              | null       | `tunnel_protocols` | "Commands the Adapter to start logging device-related data. If the log should contain data tunneled from an auxiliary device, the protocol must be specified. See [sup_protocols](#service-properties)." |
+| out  | cmd.log.start              | null       | `tunnel_protocol` | "Commands the Adapter to start logging device-related data. If the log should contain data tunneled from an auxiliary device, the protocol must be specified. See [sup_protocols](#service-properties)." |
 | out  | cmd.log.stop               | null       |                    | Commands the Adapter to stop logging device related data.                                                                                                                                                |
 
 ## Service properties

--- a/device_services/meta/diagnostic.md
+++ b/device_services/meta/diagnostic.md
@@ -1,0 +1,58 @@
+# Diagnostic Service
+
+This service allows for the control of diagnostic functionalities of associated Things. A Thing can expose a diagnostic API that enables logging of device-specific data (e.g., logging communication between the Thing and the auxiliary devices it uses or controls).
+
+## Service Name
+
+`diagnostic`
+
+## Interfaces
+
+| Type | Interface                  | Value type | Properties        | Description                                                                                                                                                                                  |
+|------|----------------------------|------------|-------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| out  | cmd.log.start              | null       | `tunnel_protocols` | Commands the Adapter to start logging device related data. If log should contain a data tunneled from auxiliary device protocol must be specified. see [`sup_protocols`](#service-properties) |
+| out  | cmd.log.stop               | null       |                   | Commands the Adapter to stop logging device related data.                                                                                                                                    |
+
+## Service properties
+
+| Name           | Example           | Description                                                            |
+|----------------|-------------------|------------------------------------------------------------------------|
+| `sup_protocols` | `["iec_61107"]`   | List of supported communication protocols to be used for thing logging |
+
+## Interface properties
+
+| Name                  | Example   | Description                                                           |
+|-----------------------|-----------|-----------------------------------------------------------------------|
+| `tunnel_protocol`     | `"m-bus"` | Protocol to be used when recording a data tunneled directly from the  |
+
+## Examples
+
+* Example of starting logging the data tunneled from smart meter using `m-bus`
+
+```json
+{
+  "serv": "diagnostic",
+  "type": "cmd.log.start",
+  "val_t": "null",
+  "val": null,
+  "props": {
+    "tunnel_protocol": "m-bus"
+  },
+  "tags": null
+}
+```
+
+* Example of deleting members from an association.
+
+```json
+{
+  "serv": "diagnostic",
+  "type": "cmd.log.stop",
+  "val_t": "null",
+  "val": null,
+  "props": null,
+  "tags": null
+}
+```
+
+

--- a/device_services/meta/diagnostic.md
+++ b/device_services/meta/diagnostic.md
@@ -8,15 +8,15 @@ This service allows for the control of diagnostic functionalities of associated 
 
 ## Interfaces
 
-| Type | Interface                  | Value type | Properties        | Description                                                                                                                                                                                  |
-|------|----------------------------|------------|-------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| out  | cmd.log.start              | null       | `tunnel_protocols` | Commands the Adapter to start logging device related data. If log should contain a data tunneled from auxiliary device protocol must be specified. see [`sup_protocols`](#service-properties) |
-| out  | cmd.log.stop               | null       |                   | Commands the Adapter to stop logging device related data.                                                                                                                                    |
+| Type | Interface                  | Value type | Properties         | Description                                                                                                                                                                                              |
+|------|----------------------------|------------|--------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| out  | cmd.log.start              | null       | `tunnel_protocols` | "Commands the Adapter to start logging device-related data. If the log should contain data tunneled from an auxiliary device, the protocol must be specified. See [sup_protocols](#service-properties)." |
+| out  | cmd.log.stop               | null       |                    | Commands the Adapter to stop logging device related data.                                                                                                                                                |
 
 ## Service properties
 
-| Name           | Example           | Description                                                            |
-|----------------|-------------------|------------------------------------------------------------------------|
+| Name            | Example           | Description                                                            |
+|-----------------|-------------------|------------------------------------------------------------------------|
 | `sup_protocols` | `["iec_61107"]`   | List of supported communication protocols to be used for thing logging |
 
 ## Interface properties
@@ -42,7 +42,7 @@ This service allows for the control of diagnostic functionalities of associated 
 }
 ```
 
-* Example of deleting members from an association.
+* Example of disabling device related data logging
 
 ```json
 {


### PR DESCRIPTION
Zigbee Cluster Library provides a way to tunnel a smart metering protocoles between the devices. Zigbee Adapter have implemented logging those data in order to give the supporting team an oportunity to find the metering device connected to HAN malfunction or misconfiguration.

Tunneling protocol in Zigbee Cluster library is explained in 10.6 paragraph of Zigbee Alliance Cluster Library Specification (based on rev 8)

The tunnel could be used as well to debug different interconected devices. 
e.g. 
Smart charger with separated Zigbee communication chip and application logic chip. Then its interconnection may be implemented to  be forwarded directly through Zigbee network to adapter which can expose malfunction of devices that were already deployed into production.